### PR TITLE
fix(worker): parse ReccoBeats audio features response correctly

### DIFF
--- a/worker/types/error.ts
+++ b/worker/types/error.ts
@@ -1,0 +1,9 @@
+/**
+ * Standardized error response format
+ */
+
+export interface ErrorResponse {
+  error: string;
+  message: string;
+  status: number;
+}

--- a/worker/types/reccobeats-api.ts
+++ b/worker/types/reccobeats-api.ts
@@ -1,0 +1,24 @@
+/**
+ * ReccoBeats API Audio Features Response Interface
+ * See: https://reccobeats.com/docs/apis/get-audio-features
+ */
+
+export interface ReccoBeatsAudioFeaturesResponse {
+  content: AudioFeature[];
+}
+
+export interface AudioFeature {
+  id: string;
+  href: string;
+  acousticness: number;
+  danceability: number;
+  energy: number;
+  instrumentalness: number;
+  key: number;
+  liveness: number;
+  loudness: number;
+  mode: number;
+  speechiness: number;
+  tempo: number;
+  valence: number;
+}


### PR DESCRIPTION
The worker was not properly handling the response from ReccoBeats API, causing valid audio feature data to be rejected by isValidAudioFeatures validator in spotify-api.ts and failing to render on the radar chart.

Changes:
- Extract ReccoBeats API response from content array (data.content[0])
- Move ErrorResponse interface to worker/types/error.ts
- Add ReccoBeatsAudioFeaturesResponse interface to worker/types/reccobeats-api.ts
- Remove trailing commas in fetchWithRetry and error responses