### PR TITLE
docs: add MIT license and update project documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Andrew
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -222,8 +222,10 @@ music-hits/
 ├── src/                          # Frontend React application
 │   ├── app.tsx                   # Main app component
 │   ├── components/               # React components
-│   ├── features/                 # Redux slices and logic
 │   ├── hooks/                    # Custom React hooks
+│   ├── lib/                      # Utility functions and helpers
+│   ├── loaders/                  # Route loaders
+│   ├── pages/                    # Page components
 │   ├── services/                 # API services
 │   ├── types/                    # TypeScript types
 │   └── vite-env.d.ts            # Vite environment types
@@ -297,10 +299,11 @@ npm test
 
 ## License
 
-[Add your license here]
+Distributed under the MIT License. See [LICENSE](LICENSE) for more information.
 
 ## Credits
 
-- **Spotify Web API** - Music data
-- **YouTube Data** - Video statistics (from local dataset)
+- **ReccoBeats API** - Tracks audio features data
+- **Spotify Web API** - Artists and tracks data
+- **YouTube Data** - Video statistics (from local dataset 2023.04)
 - **Cloudflare Workers** - Edge computing platform


### PR DESCRIPTION
This PR adds the MIT License to the project and updates the README.md to reflect the current project structure, license information, and data credits.

Changes:
- Added `LICENSE` file (MIT).
- Updated `README.md`:
    - Added License section.
    - Updated Project Structure.
    - Updated Credits (ReccoBeats API, Spotify API, YouTube Data).

zh-tw 摘要:
此 PR 新增了 MIT 授權條款，並更新 README.md 以反映目前的專案架構、授權資訊與資料來源致謝（包含 ReccoBeats API、Spotify API 與 YouTube Data）。