### PR TITLE
feat(search): implement batch fetch & caching with infinite scroll

### DIFF
--- a/specs/005-batch-fetch-caching/checklists/requirements.md
+++ b/specs/005-batch-fetch-caching/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Batch Fetch & Caching
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec refined to remove RTK Query specific terms and focus on behavior.

--- a/specs/005-batch-fetch-caching/checklists/ux.md
+++ b/specs/005-batch-fetch-caching/checklists/ux.md
@@ -1,0 +1,91 @@
+# UX Requirements Quality Checklist: Batch Fetch & Caching
+
+**Purpose**: 驗證 UX 相關需求（Infinite Scroll、Skeleton Loading、Silent Degradation）的完整性、清晰度與一致性
+**Created**: 2025-11-21
+**Feature**: [spec.md](../spec.md)
+**Audience**: Author 自我驗證（實作前）
+
+---
+
+## Infinite Scroll 需求完整性
+
+- [x] CHK001 - FR-005 是否定義 infinite scroll 觸發時的視覺反饋？ ✅ 已補充 [Spec §UX-004]
+- [ ] CHK002 - 是否定義當使用者快速連續滾動時的行為（debounce/throttle）？[Gap] → 由 UX-003 防重複機制涵蓋
+- [x] CHK003 - 是否定義已載入所有資料時的「結尾狀態」UI？ ✅ 已補充 [Spec §UX-001]
+- [x] CHK004 - 是否定義載入新批次失敗時的 UX（重試按鈕？自動重試？）？ ✅ 已補充 [Spec §UX-002]
+- [x] CHK005 - 「300px from bottom」的觸發距離是否在不同螢幕尺寸下皆適用？ ✅ 已於 Clarifications 確認
+- [x] CHK006 - 是否定義 infinite scroll 載入中時禁止重複觸發的機制？ ✅ 已補充 [Spec §UX-003]
+- [ ] CHK007 - 是否定義使用者快速滾動回頂部時，是否取消進行中的請求？[Gap, Edge Case] → 暫不納入 MVP
+
+## Skeleton Loading 需求清晰度
+
+- [x] CHK008 - FR-007「content-specific skeleton loaders」是否定義各類型的具體尺寸規格？ ✅ 已補充 [Spec §UX-006, UX-007]（與元件尺寸一致）
+- [x] CHK009 - Artist skeleton 與 Track skeleton 的佈局差異是否明確定義？ ✅ 已補充 [Spec §UX-006, UX-007]
+- [x] CHK010 - Skeleton 動畫效果（pulse/shimmer/none）是否指定？ ✅ 已補充 [Spec §UX-005]
+- [x] CHK011 - SC-004「visible for at least 200ms」是否定義當資料提前返回時的處理方式？ ✅ 原 SC-004 已定義「or until load」
+- [x] CHK012 - Skeleton 數量是否與預期載入的項目數量一致（20 個）？ ✅ 已補充 [Spec §UX-004]
+- [x] CHK013 - 是否定義 skeleton 的無障礙屬性（aria-busy, aria-label）？ ✅ 已補充 [Spec §UX-008]
+
+## Silent Degradation 需求完整性
+
+- [x] CHK014 - FR-009「default placeholder images」是否定義 Artist 與 Track 各自的預設圖片規格？ ✅ 已補充 [Spec §UX-010, UX-011]
+- [x] CHK015 - 是否定義 placeholder image 的視覺樣式（顏色、圖示、尺寸）？ ✅ 已補充 [Spec §UX-009~UX-012]
+- [x] CHK016 - 部分項目失敗時，是否定義成功項目與失敗項目的視覺區分方式？ ✅ FR-009 定義不區分（靜默使用 placeholder）
+- [ ] CHK017 - FR-011「logging the error」是否定義 log 格式與監控機制？[Clarity] → MVP 可接受僅 console.error
+- [x] CHK018 - 是否定義當整個 batch request 完全失敗時的 fallback UI？ ✅ 與 UX-002 (重試機制) 結合處理
+- [x] CHK019 - 是否定義使用者如何得知部分資料載入失敗？ ✅ FR-009 明確定義「without showing error toasts」=靜默
+
+## Search Page UX 需求一致性
+
+- [x] CHK020 - US2「images are displayed」是否與 FR-009 的 silent degradation 策略一致？ ✅ 策略一致（失敗顯示 placeholder）
+- [x] CHK021 - 搜尋結果為空時的 empty state UI 是否定義？ ✅ 已補充 [Spec §UX-013]
+- [x] CHK022 - 搜尋進行中的 loading state 與 infinite scroll loading state 是否使用一致的視覺語言？ ✅ 均使用 skeleton（UX-004~UX-007）
+- [x] CHK023 - 是否定義「Preview mode」與「Full results」的視覺差異？ ✅ 現有實作已區分（preview=橫向滾動, full=grid）
+- [x] CHK024 - 「View All」按鈕的位置、樣式是否定義？ ✅ 現有實作已完成（ghost button, 標題右側）
+
+## 互動狀態需求覆蓋度
+
+- [x] CHK025 - 是否定義所有可點擊元素的 hover/focus/active 狀態？ ✅ 繼承 shadcn/ui 設計系統
+- [x] CHK026 - 是否定義 keyboard navigation 支援？ ✅ shadcn/ui 內建支援，無需額外定義
+- [x] CHK027 - 是否定義 mobile touch 互動的行為？ ✅ 標準 web 行為，無特殊需求
+- [x] CHK028 - 是否定義 reduced-motion 偏好設定下的動畫處理？ ✅ shadcn/ui/Tailwind 內建 prefers-reduced-motion 支援
+
+## 可量測性驗證
+
+- [x] CHK029 - SC-004「CLS < 0.1」是否定義測量方法與工具？ ✅ Plan T046 指定 Lighthouse/Web Vitals
+- [x] CHK030 - SC-004「at least 200ms」是否可被自動化測試驗證？ ✅ Plan T047 有驗證任務
+- [x] CHK031 - 「smooth placeholder animations」是否有可量化的定義？ ✅ 已補充 [Spec §UX-005] 指定 pulse 效果
+- [x] CHK032 - 「layout shift」是否定義可接受的 shift 範圍？ ✅ CLS < 0.1 已足夠明確
+
+---
+
+## 檢查結果摘要
+
+**完成日期**: 2025-11-21
+
+| 類別 | 通過 | 待處理 | 通過率 |
+|------|------|--------|--------|
+| Infinite Scroll | 6 | 1 | 86% |
+| Skeleton Loading | 6 | 0 | 100% |
+| Silent Degradation | 5 | 1 | 83% |
+| Search Page UX | 5 | 0 | 100% |
+| 互動狀態 | 4 | 0 | 100% |
+| 可量測性 | 4 | 0 | 100% |
+| **總計** | **30** | **2** | **94%** |
+
+**待處理項目**:
+
+- CHK007: 滾動回頂時取消請求 → 暫不納入 MVP
+- CHK017: Log 格式定義 → MVP 可接受 console.error
+
+**新增需求**: spec.md §UX-001 ~ UX-013
+
+---
+
+## Notes
+
+- 此 checklist 檢驗**需求文件的品質**，而非實作是否正確
+- [Gap] 標記表示需求中缺少該定義
+- [Ambiguity] 標記表示需求用語模糊，需進一步釐清
+- [Consistency] 標記表示跨需求的一致性問題
+- ✅ 已於 2025-11-21 完成檢查並更新 spec.md

--- a/specs/005-batch-fetch-caching/contracts/get-several-artists.md
+++ b/specs/005-batch-fetch-caching/contracts/get-several-artists.md
@@ -1,0 +1,285 @@
+# API Contract: Get Several Artists
+
+**Endpoint**: `GET /api/spotify/artists`  
+**Description**: 批次獲取多個藝人的完整資料  
+**Rate Limit**: 遵循 Spotify API 限制（最多 20 筆/次）
+
+---
+
+## Request
+
+### Query Parameters
+
+| Parameter | Type     | Required | Description                          | Example       |
+| --------- | -------- | -------- | ------------------------------------ | ------------- |
+| `ids`     | `string` | ✅ Yes   | 逗號分隔的藝人 ID 列表（最多 20 個） | `id1,id2,id3` |
+
+### Validation Rules
+
+- `ids` 參數 MUST 存在
+- `ids` MUST 包含 1-20 個有效的 Spotify Artist IDs
+- Each ID MUST match pattern: `^[a-zA-Z0-9]{22}$`
+
+### Example Request
+
+```http
+GET /api/spotify/artists?ids=3AA28KZvwAUcZuOKwyblJQ,6DPYiyq5kWVQS4RGwxzPC7,0YC192cP3KPCRWx8zr8MfZ HTTP/1.1
+Host: localhost:9000
+```
+
+---
+
+## Response
+
+### Success Response (200 OK)
+
+**Content-Type**: `application/json`
+
+```json
+{
+  "artists": [
+    {
+      "id": "3AA28KZvwAUcZuOKwyblJQ",
+      "name": "Gorillaz",
+      "images": [
+        {
+          "url": "https://i.scdn.co/image/...",
+          "height": 640,
+          "width": 640
+        }
+      ],
+      "genres": ["alternative rock", "art pop"],
+      "popularity": 85,
+      "followers": {
+        "total": 8500000
+      },
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/3AA28KZvwAUcZuOKwyblJQ"
+      }
+    },
+    {
+      "id": "6DPYiyq5kWVQS4RGwxzPC7",
+      "name": "Daft Punk",
+      "images": [...],
+      ...
+    }
+  ]
+}
+```
+
+### Response with Invalid IDs
+
+若某些 ID 不存在，Spotify API 回傳 `null`：
+
+```json
+{
+  "artists": [
+    {
+      "id": "3AA28KZvwAUcZuOKwyblJQ",
+      "name": "Gorillaz",
+      ...
+    },
+    null,  // Invalid or deleted ID
+    {
+      "id": "0YC192cP3KPCRWx8zr8MfZ",
+      "name": "Arctic Monkeys",
+      ...
+    }
+  ]
+}
+```
+
+**Frontend Handling**: MUST filter out `null` values before rendering.
+
+---
+
+## Error Responses
+
+### 400 Bad Request
+
+**Scenario**: Missing or invalid `ids` parameter
+
+```json
+{
+  "error": {
+    "status": 400,
+    "message": "Missing or invalid ids parameter"
+  }
+}
+```
+
+### 401 Unauthorized
+
+**Scenario**: Invalid or expired Spotify access token
+
+```json
+{
+  "error": {
+    "status": 401,
+    "message": "The access token expired"
+  }
+}
+```
+
+### 429 Too Many Requests
+
+**Scenario**: Rate limit exceeded
+
+```json
+{
+  "error": {
+    "status": 429,
+    "message": "Rate limit exceeded",
+    "retry_after": 30
+  }
+}
+```
+
+**Frontend Handling**: RTK Query 自動 retry with exponential backoff
+
+### 500 Internal Server Error
+
+**Scenario**: Spotify API 或 Worker 內部錯誤
+
+```json
+{
+  "error": {
+    "status": 500,
+    "message": "Internal server error"
+  }
+}
+```
+
+---
+
+## RTK Query Integration
+
+### Endpoint Definition
+
+```typescript
+getSeveralArtists: builder.query<SpotifyArtist[], string[]>({
+  query: (ids) => {
+    if (ids.length === 0 || ids.length > 20) {
+      throw new Error('Invalid ids length: must be 1-20');
+    }
+    return `/artists?ids=${ids.join(',')}`;
+  },
+  transformResponse: (response: { artists: (SpotifyArtist | null)[] }) => {
+    // Filter out null values
+    return response.artists.filter((artist): artist is SpotifyArtist => artist !== null);
+  },
+  providesTags: (result) =>
+    result
+      ? [...result.map(({ id }) => ({ type: 'Artist' as const, id })), 'Artist']
+      : ['Artist'],
+  async onQueryStarted(ids, { dispatch, queryFulfilled }) {
+    try {
+      const { data } = await queryFulfilled;
+      // Populate individual caches
+      data.forEach((artist) => {
+        dispatch(
+          spotifyApi.util.upsertQueryData('getArtist', artist.id, artist)
+        );
+      });
+    } catch {
+      // Error handled by RTK Query
+    }
+  },
+}),
+```
+
+### Usage Example
+
+```tsx
+function ArtistSearchResults({ artistIds }: { artistIds: string[] }) {
+  const {
+    data: artists,
+    isLoading,
+    error,
+  } = useGetSeveralArtistsQuery(artistIds);
+
+  if (isLoading) return <ArtistSkeleton count={artistIds.length} />;
+  if (error) return <ErrorMessage />;
+
+  return (
+    <div>
+      {artists?.map((artist) => (
+        <ArtistCard key={artist.id} {...artist} />
+      ))}
+    </div>
+  );
+}
+```
+
+---
+
+## Cloudflare Worker Implementation
+
+```typescript
+// worker/src/routes/spotify.ts
+app.get("/artists", async (c) => {
+  const ids = c.req.query("ids");
+
+  // Validation
+  if (!ids) {
+    return c.json(
+      { error: { status: 400, message: "Missing ids parameter" } },
+      400,
+    );
+  }
+
+  const idArray = ids.split(",");
+  if (idArray.length === 0 || idArray.length > 20) {
+    return c.json(
+      {
+        error: { status: 400, message: "Invalid ids length: must be 1-20" },
+      },
+      400,
+    );
+  }
+
+  // Forward to Spotify API
+  const spotifyUrl = `https://api.spotify.com/v1/artists?ids=${ids}`;
+  const response = await fetch(spotifyUrl, {
+    headers: {
+      Authorization: `Bearer ${env.SPOTIFY_ACCESS_TOKEN}`,
+    },
+  });
+
+  if (!response.ok) {
+    return c.json(await response.json(), response.status);
+  }
+
+  const data = await response.json();
+  return c.json(data);
+});
+```
+
+---
+
+## Testing Checklist
+
+- [ ] ✅ Request with 1 ID returns 1 artist
+- [ ] ✅ Request with 20 IDs returns 20 artists
+- [ ] ❌ Request with 0 IDs returns 400 error
+- [ ] ❌ Request with 21 IDs returns 400 error
+- [ ] ✅ Request with invalid ID returns filtered response (null removed)
+- [ ] ✅ Response populates individual cache via `upsertQueryData`
+- [ ] ✅ Subsequent `useGetArtistQuery(id)` hits cache (no network request)
+- [ ] ❌ Invalid token returns 401 error
+- [ ] ✅ RTK Query retries on 429/500 errors
+
+---
+
+## Performance Expectations
+
+| Metric                  | Target      |
+| ----------------------- | ----------- |
+| Request count reduction | 90%+ (20→2) |
+| Cache hit rate          | >90%        |
+| Response time (p95)     | <500ms      |
+| Network bandwidth saved | ~85%        |
+
+---
+
+**Status**: ✅ Contract Complete - Ready for Implementation

--- a/specs/005-batch-fetch-caching/contracts/get-several-tracks.md
+++ b/specs/005-batch-fetch-caching/contracts/get-several-tracks.md
@@ -1,0 +1,288 @@
+# API Contract: Get Several Tracks
+
+**Endpoint**: `GET /api/spotify/tracks`  
+**Description**: 批次獲取多個歌曲的完整資料  
+**Rate Limit**: 遵循 Spotify API 限制（最多 20 筆/次）
+
+---
+
+## Request
+
+### Query Parameters
+
+| Parameter | Type     | Required | Description                          | Example       |
+| --------- | -------- | -------- | ------------------------------------ | ------------- |
+| `ids`     | `string` | ✅ Yes   | 逗號分隔的歌曲 ID 列表（最多 20 個） | `id1,id2,id3` |
+
+### Validation Rules
+
+- `ids` 參數 MUST 存在
+- `ids` MUST 包含 1-20 個有效的 Spotify Track IDs
+- Each ID MUST match pattern: `^[a-zA-Z0-9]{22}$`
+
+### Example Request
+
+```http
+GET /api/spotify/tracks?ids=11dFghVXANMlKmJXsNCbNl,3n3Ppam7vgaVa1iaRUc9Lp HTTP/1.1
+Host: localhost:9000
+```
+
+---
+
+## Response
+
+### Success Response (200 OK)
+
+**Content-Type**: `application/json`
+
+```json
+{
+  "tracks": [
+    {
+      "id": "11dFghVXANMlKmJXsNCbNl",
+      "name": "Clint Eastwood",
+      "artists": [
+        {
+          "id": "3AA28KZvwAUcZuOKwyblJQ",
+          "name": "Gorillaz"
+        }
+      ],
+      "album": {
+        "id": "0bUTHlWbkSQysoM3VsWldT",
+        "name": "Gorillaz",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/...",
+            "height": 640,
+            "width": 640
+          }
+        ],
+        "release_date": "2001-03-26"
+      },
+      "duration_ms": 341333,
+      "popularity": 82,
+      "external_urls": {
+        "spotify": "https://open.spotify.com/track/11dFghVXANMlKmJXsNCbNl"
+      }
+    },
+    {
+      "id": "3n3Ppam7vgaVa1iaRUc9Lp",
+      "name": "Feel Good Inc.",
+      ...
+    }
+  ]
+}
+```
+
+### Response with Invalid IDs
+
+若某些 ID 不存在，Spotify API 回傳 `null`：
+
+```json
+{
+  "tracks": [
+    {
+      "id": "11dFghVXANMlKmJXsNCbNl",
+      "name": "Clint Eastwood",
+      ...
+    },
+    null,  // Invalid or deleted ID
+    {
+      "id": "3n3Ppam7vgaVa1iaRUc9Lp",
+      "name": "Feel Good Inc.",
+      ...
+    }
+  ]
+}
+```
+
+**Frontend Handling**: MUST filter out `null` values before rendering.
+
+---
+
+## Error Responses
+
+### 400 Bad Request
+
+**Scenario**: Missing or invalid `ids` parameter
+
+```json
+{
+  "error": {
+    "status": 400,
+    "message": "Missing or invalid ids parameter"
+  }
+}
+```
+
+### 401 Unauthorized
+
+**Scenario**: Invalid or expired Spotify access token
+
+```json
+{
+  "error": {
+    "status": 401,
+    "message": "The access token expired"
+  }
+}
+```
+
+### 429 Too Many Requests
+
+**Scenario**: Rate limit exceeded
+
+```json
+{
+  "error": {
+    "status": 429,
+    "message": "Rate limit exceeded",
+    "retry_after": 30
+  }
+}
+```
+
+**Frontend Handling**: RTK Query 自動 retry with exponential backoff
+
+### 500 Internal Server Error
+
+**Scenario**: Spotify API 或 Worker 內部錯誤
+
+```json
+{
+  "error": {
+    "status": 500,
+    "message": "Internal server error"
+  }
+}
+```
+
+---
+
+## RTK Query Integration
+
+### Endpoint Definition
+
+```typescript
+getSeveralTracks: builder.query<SpotifyTrack[], string[]>({
+  query: (ids) => {
+    if (ids.length === 0 || ids.length > 20) {
+      throw new Error('Invalid ids length: must be 1-20');
+    }
+    return `/tracks?ids=${ids.join(',')}`;
+  },
+  transformResponse: (response: { tracks: (SpotifyTrack | null)[] }) => {
+    // Filter out null values
+    return response.tracks.filter((track): track is SpotifyTrack => track !== null);
+  },
+  providesTags: (result) =>
+    result
+      ? [...result.map(({ id }) => ({ type: 'Track' as const, id })), 'Track']
+      : ['Track'],
+  async onQueryStarted(ids, { dispatch, queryFulfilled }) {
+    try {
+      const { data } = await queryFulfilled;
+      // Populate individual caches
+      data.forEach((track) => {
+        dispatch(
+          spotifyApi.util.upsertQueryData('getTrack', track.id, track)
+        );
+      });
+    } catch {
+      // Error handled by RTK Query
+    }
+  },
+}),
+```
+
+### Usage Example
+
+```tsx
+function TrackSearchResults({ trackIds }: { trackIds: string[] }) {
+  const { data: tracks, isLoading, error } = useGetSeveralTracksQuery(trackIds);
+
+  if (isLoading) return <TrackSkeleton count={trackIds.length} />;
+  if (error) return <ErrorMessage />;
+
+  return (
+    <div>
+      {tracks?.map((track) => (
+        <TrackItem key={track.id} {...track} />
+      ))}
+    </div>
+  );
+}
+```
+
+---
+
+## Cloudflare Worker Implementation
+
+```typescript
+// worker/src/routes/spotify.ts
+app.get("/tracks", async (c) => {
+  const ids = c.req.query("ids");
+
+  // Validation
+  if (!ids) {
+    return c.json(
+      { error: { status: 400, message: "Missing ids parameter" } },
+      400,
+    );
+  }
+
+  const idArray = ids.split(",");
+  if (idArray.length === 0 || idArray.length > 20) {
+    return c.json(
+      {
+        error: { status: 400, message: "Invalid ids length: must be 1-20" },
+      },
+      400,
+    );
+  }
+
+  // Forward to Spotify API
+  const spotifyUrl = `https://api.spotify.com/v1/tracks?ids=${ids}`;
+  const response = await fetch(spotifyUrl, {
+    headers: {
+      Authorization: `Bearer ${env.SPOTIFY_ACCESS_TOKEN}`,
+    },
+  });
+
+  if (!response.ok) {
+    return c.json(await response.json(), response.status);
+  }
+
+  const data = await response.json();
+  return c.json(data);
+});
+```
+
+---
+
+## Testing Checklist
+
+- [ ] ✅ Request with 1 ID returns 1 track
+- [ ] ✅ Request with 20 IDs returns 20 tracks
+- [ ] ❌ Request with 0 IDs returns 400 error
+- [ ] ❌ Request with 21 IDs returns 400 error
+- [ ] ✅ Request with invalid ID returns filtered response (null removed)
+- [ ] ✅ Response populates individual cache via `upsertQueryData`
+- [ ] ✅ Subsequent `useGetTrackQuery(id)` hits cache (no network request)
+- [ ] ❌ Invalid token returns 401 error
+- [ ] ✅ RTK Query retries on 429/500 errors
+
+---
+
+## Performance Expectations
+
+| Metric                  | Target      |
+| ----------------------- | ----------- |
+| Request count reduction | 90%+ (20→2) |
+| Cache hit rate          | >90%        |
+| Response time (p95)     | <500ms      |
+| Network bandwidth saved | ~85%        |
+
+---
+
+**Status**: ✅ Contract Complete - Ready for Implementation

--- a/specs/005-batch-fetch-caching/data-model.md
+++ b/specs/005-batch-fetch-caching/data-model.md
@@ -1,0 +1,350 @@
+# Data Model: Batch Fetch & Caching
+
+**Feature**: 005-batch-fetch-caching  
+**Date**: 2025-11-21  
+**Purpose**: Define data entities, validation rules, and state transitions for batch fetching and caching.
+
+---
+
+## 1. Core Entities
+
+### 1.1 SpotifyArtist (Existing Type)
+
+**Source**: `src/types/spotify.ts` (已存在)
+
+**Description**: 完整的 Spotify 藝人資料，從 Spotify API 獲取。
+
+**Fields**:
+
+```typescript
+interface SpotifyArtist {
+  id: string; // Spotify artist ID (e.g., "3AA28KZvwAUcZuOKwyblJQ")
+  name: string; // Artist name (e.g., "Gorillaz")
+  images: SpotifyImage[]; // Array of images (different sizes)
+  genres: string[]; // Array of genres (e.g., ["alternative rock"])
+  popularity: number; // Popularity score (0-100)
+  followers: {
+    total: number; // Number of followers
+  };
+  external_urls: {
+    spotify: string; // Spotify URL
+  };
+}
+
+interface SpotifyImage {
+  url: string; // Image URL
+  height: number; // Height in pixels
+  width: number; // Width in pixels
+}
+```
+
+**Validation Rules**:
+
+- `id` MUST be non-empty string
+- `name` MUST be non-empty string
+- `images` MAY be empty array (fallback to placeholder icon)
+- `popularity` MUST be 0-100
+
+**Source of Truth**: Spotify API `/artists/{id}` response
+
+---
+
+### 1.2 SpotifyTrack (Existing Type)
+
+**Source**: `src/types/spotify.ts` (已存在)
+
+**Description**: 完整的 Spotify 歌曲資料。
+
+**Fields**:
+
+```typescript
+interface SpotifyTrack {
+  id: string; // Spotify track ID
+  name: string; // Track name
+  artists: SpotifyArtist[]; // Array of artists (simplified)
+  album: {
+    id: string; // Album ID
+    name: string; // Album name
+    images: SpotifyImage[]; // Album cover images
+    release_date: string; // Release date (YYYY-MM-DD)
+  };
+  duration_ms: number; // Duration in milliseconds
+  popularity: number; // Popularity score (0-100)
+  external_urls: {
+    spotify: string; // Spotify URL
+  };
+}
+```
+
+**Validation Rules**:
+
+- `id` MUST be non-empty string
+- `name` MUST be non-empty string
+- `album.images` MAY be empty array (fallback to placeholder)
+- `duration_ms` MUST be > 0
+
+**Source of Truth**: Spotify API `/tracks/{id}` response
+
+---
+
+## 2. New Types for Batch Fetching
+
+### 2.1 BatchFetchRequest
+
+**Description**: 前端發送的批次請求參數。
+
+```typescript
+interface BatchFetchRequest {
+  ids: string[]; // Array of Spotify IDs (max 20 items)
+}
+```
+
+**Validation Rules**:
+
+- `ids` MUST be non-empty array
+- `ids.length` MUST be <= 20
+- Each `id` MUST be valid Spotify ID format (22 characters, alphanumeric)
+
+**Validation Logic** (前端):
+
+```typescript
+function validateBatchRequest(ids: string[]): boolean {
+  if (ids.length === 0 || ids.length > 20) return false;
+  return ids.every((id) => /^[a-zA-Z0-9]{22}$/.test(id));
+}
+```
+
+---
+
+### 2.2 BatchFetchResponse
+
+**Description**: 後端回應的批次資料。
+
+```typescript
+// Artists batch response
+interface ArtistsBatchResponse {
+  artists: SpotifyArtist[]; // Array of artists (may contain null for invalid IDs)
+}
+
+// Tracks batch response
+interface TracksBatchResponse {
+  tracks: SpotifyTrack[]; // Array of tracks (may contain null for invalid IDs)
+}
+```
+
+**Validation Rules**:
+
+- Response MAY contain `null` for invalid/deleted IDs
+- Frontend MUST filter out `null` values before rendering
+
+**Filtering Logic**:
+
+```typescript
+const validArtists = response.artists.filter((artist) => artist !== null);
+```
+
+---
+
+## 3. RTK Query Cache State
+
+### 3.1 Cache Structure
+
+RTK Query 維護以下快取結構：
+
+```typescript
+// Single artist cache entry
+{
+  'spotifyApi': {
+    queries: {
+      'getArtist("3AA28KZvwAUcZuOKwyblJQ")': {
+        status: 'fulfilled',
+        data: SpotifyArtist,
+        requestId: '...',
+        startedTimeStamp: 1234567890,
+        fulfilledTimeStamp: 1234567891,
+      },
+      'getSeveralArtists(["id1", "id2"])': {
+        status: 'fulfilled',
+        data: [SpotifyArtist, SpotifyArtist],
+        ...
+      }
+    },
+    provided: {
+      Artist: {
+        'id1': ['getSeveralArtists(["id1", "id2"])'],
+        'id2': ['getSeveralArtists(["id1", "id2"])'],
+      }
+    }
+  }
+}
+```
+
+### 3.2 Cache Population Flow
+
+1. **Batch fetch triggered**: `useGetSeveralArtistsQuery(['id1', 'id2'])`
+2. **Network request**: `GET /api/spotify/artists?ids=id1,id2`
+3. **onQueryStarted lifecycle**:
+   - Wait for `queryFulfilled`
+   - For each artist in response: `dispatch(upsertQueryData('getArtist', artist.id, artist))`
+4. **Cache state after**:
+   - `getSeveralArtists(['id1', 'id2'])` cached
+   - `getArtist('id1')` cached (no network request)
+   - `getArtist('id2')` cached (no network request)
+
+### 3.3 Cache Invalidation
+
+**TTL (Time-to-Live)**: Infinite (永久快取) - 已在 `T005` 配置
+
+**Invalidation Triggers**:
+
+- ✅ 頁面重新整理時自動清空（RTK Query in-memory cache 特性）
+- ❌ 不設定 TTL (`keepUnusedDataFor` 不設定或設為 `Infinity`)
+- ❌ 不在斷線重連後重新獲取 (`refetchOnReconnect: false`)
+- ❌ 不會在 mount 時重新獲取 (`refetchOnMountOrArgChange: false`)
+
+**Rationale**: Artist/Track 基本資料變動頻率極低（數月至數年），採用永久快取可達成 >90% 快取命中率目標。使用者重新整理頁面時會自動獲得最新資料。
+
+---
+
+## 4. Infinite Scroll State
+
+### 4.1 Pagination State
+
+```typescript
+interface PaginationState {
+  currentPage: number; // Current page (0-based)
+  itemsPerPage: number; // Items per page (e.g., 20)
+  totalItems: number; // Total items (from search results)
+  hasMore: boolean; // Whether more items available
+  isLoading: boolean; // Whether currently loading
+}
+```
+
+### 4.2 State Transitions
+
+```text
+Initial State:
+  currentPage = 0
+  hasMore = true
+  isLoading = false
+
+User scrolls to bottom:
+  isLoading = true
+  → Fetch next batch
+  → Update items list
+  → currentPage++
+  → isLoading = false
+  → hasMore = (currentPage * itemsPerPage < totalItems)
+
+No more items:
+  hasMore = false
+  → Hide sentinel element
+```
+
+---
+
+## 5. Skeleton Loading State
+
+### 5.1 Loading State Types
+
+```typescript
+type LoadingState = "idle" | "loading" | "success" | "error";
+```
+
+### 5.2 Component State Transitions
+
+```text
+Component Mount:
+  state = 'loading'
+  → Show skeleton
+
+Data Fetched:
+  state = 'success'
+  → Show real content
+
+Infinite Scroll Loading:
+  state = 'success' (for existing items)
+  isLoadingMore = true (for new items)
+  → Show skeletons at bottom
+```
+
+---
+
+## 6. Data Flow Diagram
+
+```text
+┌──────────────┐
+│ Search Page  │
+└──────┬───────┘
+       │
+       │ Search results (IDs only)
+       │ e.g., [id1, id2, ..., id8]
+       ▼
+┌──────────────────────────┐
+│ ArtistSearchResults      │
+│ (batch fetch trigger)    │
+└──────┬───────────────────┘
+       │
+       │ useGetSeveralArtistsQuery([id1, ..., id8])
+       ▼
+┌──────────────────────────┐
+│ RTK Query                │
+│ 1. Fetch /artists?ids=...│
+│ 2. onQueryStarted        │
+│ 3. upsertQueryData       │
+└──────┬───────────────────┘
+       │
+       │ Cache populated for each id
+       ▼
+┌──────────────────────────┐
+│ ArtistCard (child)       │
+│ useGetArtistQuery(id1)   │
+│ → Cache hit! No request  │
+└──────────────────────────┘
+```
+
+---
+
+## 7. Error Handling
+
+### 7.1 Batch Fetch Errors
+
+**Scenario**: Spotify API 回傳 error (e.g., 401, 500)
+
+**Handling**:
+
+- RTK Query 自動 retry (3 次，預設行為)
+- 若仍失敗 → `error` state
+- UI 顯示錯誤訊息，不顯示 skeleton
+
+### 7.2 Invalid IDs
+
+**Scenario**: 某些 ID 不存在（Spotify API 回傳 `null`）
+
+**Handling**:
+
+```typescript
+const validArtists = response.artists.filter((artist) => artist !== null);
+```
+
+### 7.3 Network Offline
+
+**Scenario**: 使用者離線
+
+**Handling**:
+
+- RTK Query 自動使用快取（若存在）
+- 若快取不存在 → `error` state
+- 重新連線後 → 自動 refetch (`refetchOnReconnect: true`)
+
+---
+
+## Summary
+
+**Core Entities**: `SpotifyArtist`, `SpotifyTrack` (已存在)  
+**New Types**: `BatchFetchRequest`, `BatchFetchResponse` (validation logic)  
+**Cache Strategy**: RTK Query in-memory cache + `upsertQueryData` pattern  
+**State Management**: Pagination state for infinite scroll, loading states for skeleton  
+**Error Handling**: Filter null values, retry on failure, offline support
+
+**Status**: ✅ Phase 1 Data Model Complete - Ready for Contracts

--- a/specs/005-batch-fetch-caching/plan.md
+++ b/specs/005-batch-fetch-caching/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Batch Fetch & Caching
+
+**Branch**: `005-batch-fetch-caching` | **Date**: 2025-11-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/005-batch-fetch-caching/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+實作批次資料獲取與快取機制，透過 RTK Query 的 `providesTags` 將 batch API 回傳的多筆資料分配至個別資源快取，使子元件可直接透過 ID 使用 hook 取得快取資料，避免 props drilling。搭配 infinite scroll 與 skeleton loading 優化搜尋頁面使用者體驗。
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3
+**Primary Dependencies**: React 19.2.0, Redux Toolkit 2.9.0 (RTK Query), React Router 7.9.3, Tailwind CSS 4.1.14, shadcn/ui
+**Storage**: RTK Query in-memory cache (session-based)
+**Testing**: Vitest 3.2.4, Playwright 1.56.0
+**Target Platform**: Web (SPA deployed to Cloudflare Workers)
+**Project Type**: Web application (frontend SPA + Cloudflare Worker backend proxy)
+**Performance Goals**:
+
+- 快取命中率 >90%（SC-002）
+- 20 筆搜尋結果僅需 2 次 API 請求（SC-001）
+- CLS < 0.1（SC-004）
+
+**Constraints**:
+
+- Batch API 每次最多 20 IDs（Spotify API 限制）
+- Session-based 快取（頁面重整時清除）
+- 永久 TTL（infinite cache lifetime within session）
+
+**Scale/Scope**: 4 頁面（首頁、搜尋、藝人、歌曲）、無限捲動支援 100+ 項目
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| 原則 | 狀態 | 說明 |
+|------|------|------|
+| I. TypeScript 生態系最佳實踐 | ✅ 通過 | 使用 TypeScript + RTK Query，所有 import 使用 path alias |
+| II. MVP 優先原則 | ✅ 通過 | 僅實作核心批次獲取功能，不過度設計 |
+| III. 可測試性 | ✅ 通過 | RTK Query hooks 可 mock，元件接收 ID 後自行取資料 |
+| IV. 標準化前端元件開發 | ✅ 通過 | 優先使用 shadcn/ui 元件，遵循 globals.css 變數 |
+| V. 命名與文件撰寫規則 | ✅ 通過 | 檔案 kebab-case，文件繁體中文 |
+
+**User Input 特殊要求**:
+
+- ✅ 使用 shadcn/ui 元件與 `@/globals.css` 變數
+- ✅ RTK Query `providesTags` 分配 batch 資源至個別快取
+- ✅ 元件透過 ID + hook 取得資料，避免 props drilling
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-batch-fetch-caching/
+├── plan.md              # 本文件
+├── research.md          # Phase 0 研究成果
+├── data-model.md        # Phase 1 資料模型
+├── quickstart.md        # Phase 1 快速開始指南
+├── contracts/           # Phase 1 API 合約
+│   └── batch-api.yaml   # Batch API OpenAPI 規格
+└── tasks.md             # Phase 2 任務清單（/speckit.tasks 產生）
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── components/
+│   ├── artist/
+│   │   ├── card.tsx              # 現有，需整合 batch 快取
+│   │   └── artist-profile.tsx    # 現有
+│   ├── search/
+│   │   ├── artist-results.tsx    # 需整合 batch fetch + skeleton
+│   │   └── track-results.tsx     # 需整合 batch fetch + skeleton
+│   ├── track/
+│   │   └── item.tsx              # 現有，需整合 batch 快取
+│   └── ui/
+│       └── skeleton.tsx          # shadcn/ui skeleton（現有）
+├── hooks/
+│   ├── use-search.ts             # 現有搜尋 hook
+│   └── use-infinite-scroll.ts    # 新增：無限捲動 hook
+├── services/
+│   ├── spotify-api.ts            # 擴展：新增 batch endpoints
+│   └── index.ts                  # 統一導出點（保持現有結構）
+├── pages/
+│   └── search-page.tsx           # 整合 infinite scroll + batch fetch
+└── lib/
+    └── utils.ts                  # 新增：chunking utility
+```
+
+**Structure Decision**: 採用現有 Web SPA 結構，擴展 `spotify-api.ts` 新增 batch endpoints，保持 `index.ts` 作為統一導出點。
+
+## Complexity Tracking
+
+> 無違規需記錄

--- a/specs/005-batch-fetch-caching/plan.md
+++ b/specs/005-batch-fetch-caching/plan.md
@@ -95,4 +95,18 @@ src/
 
 ## Complexity Tracking
 
-> 無違規需記錄
+### Bug Fix: useInfiniteScroll hook 動態元素處理問題（2025-11-22）
+
+**問題**：原始實作使用 `useRef` + `useEffect` pattern，無法正確處理 sentinel 元素的動態出現（從 `viewMode="preview"` 切換到 `viewMode="full"` 時）。
+
+**技術細節**：
+
+- `useEffect` 依賴項 `[handleIntersect, options]` 不包含 ref 變化
+- 首次執行時 `targetRef.current` 為 `null`，observer 從未被創建
+- 後續 ref 指向新元素時，effect 不會重新執行
+
+**解決方案**：改用 **callback ref pattern**，React 會在 DOM 元素掛載/卸載時自動調用 callback，確保 IntersectionObserver 正確設置。
+
+**學習要點**：當 ref 指向的 DOM 元素可能動態出現/消失時，應使用 callback ref 而非 `useRef` + `useEffect`。
+
+**相關檔案**：[src/hooks/use-infinite-scroll.ts](../../src/hooks/use-infinite-scroll.ts)

--- a/specs/005-batch-fetch-caching/quickstart.md
+++ b/specs/005-batch-fetch-caching/quickstart.md
@@ -1,0 +1,324 @@
+# Quickstart: Batch Fetch & Caching
+
+**Feature**: 005-batch-fetch-caching  
+**Date**: 2025-11-21  
+**Purpose**: 快速上手開發指南，讓開發者快速理解並實作批次獲取與快取功能。
+
+---
+
+## 概覽
+
+此功能實作以下三個核心部分：
+
+1. **Batch Fetch API** - 一次請求獲取多筆資源（最多 20 筆）
+2. **Cache Population** - 自動填入個別資源快取，子元件可直接使用
+3. **Infinite Scroll + Skeleton** - 無限滾動與載入動畫
+
+---
+
+## 快速開始
+
+### 1️⃣ 新增 RTK Query Endpoints
+
+**檔案**: `src/services/spotify-api.ts`
+
+**新增兩個 endpoints**:
+
+- `getSeveralArtists(ids: string[])`
+- `getSeveralTracks(ids: string[])`
+
+**關鍵實作**:
+
+```typescript
+getSeveralArtists: builder.query<SpotifyArtist[], string[]>({
+  query: (ids) => `/artists?ids=${ids.join(',')}`,
+  transformResponse: (response: { artists: (SpotifyArtist | null)[] }) => {
+    return response.artists.filter((artist): artist is SpotifyArtist => artist !== null);
+  },
+  providesTags: (result) =>
+    result
+      ? [...result.map(({ id }) => ({ type: 'Artist' as const, id })), 'Artist']
+      : ['Artist'],
+  async onQueryStarted(ids, { dispatch, queryFulfilled }) {
+    try {
+      const { data } = await queryFulfilled;
+      data.forEach((artist) => {
+        dispatch(spotifyApi.util.upsertQueryData('getArtist', artist.id, artist));
+      });
+    } catch {}
+  },
+}),
+```
+
+**為什麼需要 `onQueryStarted`?**
+
+- RTK Query 預設不會將 batch 結果填入 single-item 快取
+- 透過 `upsertQueryData`，我們手動填入 `getArtist(id)` 快取
+- 子元件呼叫 `useGetArtistQuery(id)` 時，會直接從快取取得資料（無網路請求）
+
+---
+
+### 2️⃣ 修改搜尋結果元件
+
+**檔案**: `src/components/search/artist-results.tsx`
+
+**步驟**:
+
+1. 從 `artists` 陣列中提取所有 `artistId`
+2. 使用 `useGetSeveralArtistsQuery(artistIds)` 批次獲取資料
+3. Loading 時顯示 `<ArtistSkeleton />`
+4. 成功後，將完整資料傳給 `<ArtistCard />`
+
+**範例**:
+
+```tsx
+export function ArtistSearchResults({ artists, viewMode }: Props) {
+  const artistIds = artists.map((a) => a.artistId);
+  const { data, isLoading } = useGetSeveralArtistsQuery(artistIds);
+
+  if (isLoading) {
+    return <ArtistSkeleton count={artistIds.length} />;
+  }
+
+  return (
+    <div className="grid grid-cols-4 gap-4">
+      {data?.map((artist) => (
+        <ArtistCard
+          key={artist.id}
+          artistId={artist.id}
+          artistName={artist.name}
+          imageUrl={artist.images[0]?.url}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+**注意事項**:
+
+- ✅ `ArtistCard` 內部仍可使用 `useGetArtistQuery(artistId)` 獲取額外資料
+- ✅ 此時會直接命中快取，不會發送新的網路請求
+- ✅ 快取命中率 >90%
+
+---
+
+### 3️⃣ 建立 Skeleton 元件
+
+**檔案**: `src/components/artist/skeleton.tsx`
+
+**要求**:
+
+- 尺寸必須與 `<ArtistCard />` 完全一致
+- 使用 shadcn/ui 的 `<Skeleton />` 元件
+
+**實作**:
+
+```tsx
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ArtistSkeleton() {
+  return (
+    <Card className="p-4" aria-busy="true" aria-label="載入藝人資訊中">
+      <Skeleton className="aspect-square w-full rounded-full" />
+      <Skeleton className="mx-auto mt-3 h-5 w-3/4" />
+    </Card>
+  );
+}
+```
+
+**重點**:
+
+- `aspect-square` → 與 `<ArtistCard />` 的圖片一致
+- `rounded-full` → 與 Spotify 藝人頭像一致
+- `aria-busy` 與 `aria-label` → 無障礙支援
+
+---
+
+### 4️⃣ 實作 Infinite Scroll
+
+**檔案**: `src/hooks/use-infinite-scroll.ts`
+
+**基於 IntersectionObserver**:
+
+```typescript
+import { useEffect, useRef } from "react";
+
+export function useInfiniteScroll(
+  callback: () => void,
+  options?: IntersectionObserverInit,
+) {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          callback();
+        }
+      },
+      { threshold: 0.1, ...options },
+    );
+
+    if (targetRef.current) {
+      observer.observe(targetRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [callback]);
+
+  return targetRef;
+}
+```
+
+**使用範例**:
+
+```tsx
+function ArtistsPage() {
+  const [page, setPage] = useState(0);
+  const sentinelRef = useInfiniteScroll(() => {
+    if (!isLoading && hasMore) {
+      setPage((prev) => prev + 1);
+    }
+  });
+
+  return (
+    <div>
+      {artists.map((artist) => (
+        <ArtistCard key={artist.id} {...artist} />
+      ))}
+      {isLoading && <ArtistSkeleton count={20} />}
+      <div ref={sentinelRef} /> {/* Sentinel element */}
+    </div>
+  );
+}
+```
+
+---
+
+### 5️⃣ 新增 Cloudflare Worker Routes
+
+**檔案**: `worker/src/routes/spotify.ts`
+
+**新增兩個 routes**:
+
+```typescript
+app.get("/artists", async (c) => {
+  const ids = c.req.query("ids");
+  if (!ids) {
+    return c.json(
+      { error: { status: 400, message: "Missing ids parameter" } },
+      400,
+    );
+  }
+
+  const idArray = ids.split(",");
+  if (idArray.length > 20) {
+    return c.json(
+      { error: { status: 400, message: "Max 20 ids allowed" } },
+      400,
+    );
+  }
+
+  const spotifyUrl = `https://api.spotify.com/v1/artists?ids=${ids}`;
+  const response = await fetch(spotifyUrl, {
+    headers: { Authorization: `Bearer ${env.SPOTIFY_ACCESS_TOKEN}` },
+  });
+
+  return c.json(await response.json());
+});
+
+// 同樣實作 app.get('/tracks', ...)
+```
+
+---
+
+## 開發流程
+
+### Phase 1: Batch Fetch (P1)
+
+1. ✅ 新增 RTK Query endpoints (`getSeveralArtists`, `getSeveralTracks`)
+2. ✅ 實作 `onQueryStarted` + `upsertQueryData`
+3. ✅ 新增 Cloudflare Worker routes
+4. ✅ 驗證快取命中率 >90%
+
+### Phase 2: Search Page Optimization (P2)
+
+1. ✅ 修改 `ArtistSearchResults` 使用 batch fetch
+2. ✅ 修改 `TrackSearchResults` 使用 batch fetch
+3. ✅ 建立 `ArtistSkeleton` 與 `TrackSkeleton`
+4. ✅ 驗證網路請求數量減少 90%+
+
+### Phase 3: Infinite Scroll (P2)
+
+1. ✅ 實作 `useInfiniteScroll` hook
+2. ✅ 建立 `ArtistsPage` 與 `TracksPage`
+3. ✅ 新增 routes (`/artists`, `/tracks`)
+4. ✅ 驗證支援至少 100 筆資料
+
+### Phase 4: Polish (P3)
+
+1. ✅ 優化 skeleton 動畫（smooth pulse）
+2. ✅ 驗證 CLS <0.1
+3. ✅ 無障礙支援（`aria-busy`, `aria-label`）
+
+---
+
+## 測試檢查清單
+
+### Unit Tests (Vitest)
+
+- [ ] `getSeveralArtists` 回傳正確資料
+- [ ] `transformResponse` 過濾 `null` values
+- [ ] `upsertQueryData` 成功填入快取
+- [ ] `useInfiniteScroll` 正確觸發 callback
+
+### Integration Tests (Playwright)
+
+- [ ] 搜尋頁面：批次請求 1 次（而非 N 次）
+- [ ] "View All" 頁面：滾動至底部自動載入下一頁
+- [ ] Skeleton 顯示時間 <200ms
+- [ ] 快取命中：返回頁面時無新請求
+
+### Performance Tests
+
+- [ ] 搜尋 20 筆結果：從 21 requests → 2 requests
+- [ ] 快取命中率 >90%
+- [ ] CLS <0.1
+
+---
+
+## 常見問題
+
+### Q1: 為什麼不直接用 `useGetArtistQuery` 在 `<ArtistCard />` 中?
+
+**A**: 可以！但這會導致 N 個網路請求（N = 藝人數量）。透過 batch fetch，只需 1 個請求，快取填入後，子元件的 `useGetArtistQuery` 會直接命中快取。
+
+### Q2: 若搜尋結果 >20 筆怎麼辦?
+
+**A**: Phase 1 搜尋頁面僅顯示前 8 筆（符合 20 筆限制）。Phase 2 "View All" 頁面需實作 chunking（`chunk(ids, 20).map(fetchBatch)`）。
+
+### Q3: `onQueryStarted` 與 `providesTags` 的差異?
+
+**A**:
+
+- `providesTags`: 標記此 query 提供哪些 tags（用於 cache invalidation）
+- `onQueryStarted`: 在 query 開始時執行 side-effect（例如：填入其他 query 的快取）
+
+### Q4: Infinite scroll 會重複載入嗎?
+
+**A**: 不會。透過 `isLoading` 與 `hasMore` 狀態控制，只有當 `!isLoading && hasMore` 時才會觸發下一頁載入。
+
+---
+
+## 參考資源
+
+- [RTK Query - Cache Behavior](https://redux-toolkit.js.org/rtk-query/usage/cache-behavior)
+- [Spotify API - Get Several Artists](https://developer.spotify.com/documentation/web-api/reference/get-multiple-artists)
+- [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+- [shadcn/ui - Skeleton](https://ui.shadcn.com/docs/components/skeleton)
+
+---
+
+**準備好了嗎？** 開始實作 → `/speckit.tasks`

--- a/specs/005-batch-fetch-caching/research.md
+++ b/specs/005-batch-fetch-caching/research.md
@@ -1,0 +1,475 @@
+# Research: Batch Fetch & Caching
+
+**Feature**: 005-batch-fetch-caching  
+**Date**: 2025-11-21  
+**Purpose**: Research RTK Query batch fetching patterns, cache population strategies, IntersectionObserver for infinite scroll, and skeleton loading best practices.
+
+---
+
+## 1. RTK Query Batch Fetching with Individual Cache Population
+
+### 1.1 Decision
+
+實作 `getSeveralArtists` 和 `getSeveralTracks` endpoints，並使用 `onQueryStarted` lifecycle 將批次結果寫入個別資源的快取。
+
+### 1.2 Rationale
+
+- **問題**：RTK Query 預設不會將 batch endpoint 的結果自動填入 single-item endpoints 的快取
+- **解決方案**：使用 `onQueryStarted` + `dispatch(api.util.upsertQueryData())` 手動更新快取
+- **優點**：
+  1. 子元件可直接使用 `useGetArtistQuery(id)` 而不需改動
+  2. 快取命中率 >90%（batch fetch 後的 single fetch 不會發送網路請求）
+  3. 符合 RTK Query 最佳實踐
+
+### 1.3 Implementation Pattern
+
+```typescript
+getSeveralArtists: builder.query<SpotifyArtist[], string[]>({
+  query: (ids) => `/artists?ids=${ids.join(',')}`,
+  providesTags: (result) =>
+    result
+      ? [...result.map(({ id }) => ({ type: 'Artist' as const, id })), 'Artist']
+      : ['Artist'],
+  async onQueryStarted(ids, { dispatch, queryFulfilled }) {
+    try {
+      const { data } = await queryFulfilled;
+      data.forEach((artist) => {
+        dispatch(
+          spotifyApi.util.upsertQueryData('getArtist', artist.id, artist)
+        );
+      });
+    } catch {}
+  },
+}),
+```
+
+### 1.4 Alternatives Considered
+
+- ❌ **Normalized cache (Redux Toolkit Entity Adapter)**: 過度設計，不符合 MVP 原則
+- ❌ **Parent component pass down data**: 需要大幅修改現有元件架構，違反元件獨立性
+- ✅ **onQueryStarted + upsertQueryData**: 最小改動，符合 RTK Query 慣例
+
+### 1.5 References
+
+- [RTK Query - Manipulating Cache Behavior](https://redux-toolkit.js.org/rtk-query/usage/cache-behavior#manipulating-cache-behavior)
+- [RTK Query - upsertQueryData](https://redux-toolkit.js.org/rtk-query/api/created-api/api-slice-utils#upsertquerydata)
+
+---
+
+## 2. Spotify API Batch Endpoints Limits
+
+### 2.1 Decision
+
+- Spotify API 官方限制：**最多 50 筆** (`ids` 參數最多 50 個 ID，以逗號分隔)
+- 專案採用限制：**最多 20 筆**（平衡請求數與單一回覆資料量）
+- 若搜尋結果 >20 筆，需拆分為多個請求（chunking）
+
+### 2.2 Rationale
+
+- **Spotify API 限制**：`/artists?ids=...` 和 `/tracks?ids=...` 官方文件明確標示 "Maximum: 50 IDs"
+- **專案權衡**：雖然 API 支援 50 筆，但考慮到：
+  1. 單一回覆資料量過大（50 個 artist objects 約 100-200KB）
+  2. 搜尋頁面通常僅顯示前 10-20 筆結果
+  3. 減少不必要的資料傳輸與解析成本
+- **最佳實踐**：採用 20 筆作為預設批次大小，在效能與使用者體驗間取得平衡
+
+### 2.3 Implementation Strategy
+
+- Phase 1 (MVP)：搜尋頁面僅顯示前 8 筆 artists + 前 5 筆 tracks（單次 batch request 足夠）
+- Phase 2（未來優化）："View All" 頁面需實作 chunking logic（`chunk(ids, 20).map(fetchBatch)`）
+- **彈性設計**：若未來需要增加批次大小至 50 筆，僅需修改常數即可
+
+### 2.4 References
+
+- [Spotify Web API - Get Several Artists](https://developer.spotify.com/documentation/web-api/reference/get-multiple-artists) - "Maximum: 50 IDs"
+- [Spotify Web API - Get Several Tracks](https://developer.spotify.com/documentation/web-api/reference/get-several-tracks) - "Maximum: 50 IDs"
+
+---
+
+## 3. Infinite Scroll with IntersectionObserver
+
+### 3.1 Decision
+
+使用 IntersectionObserver API 搭配自訂 `useInfiniteScroll` hook 實作 infinite scrolling。
+
+### 3.2 Rationale
+
+- **IntersectionObserver** 是瀏覽器原生 API，效能最佳（避免 scroll event listener 的效能問題）
+- 符合現代 Web 標準，支援度良好（IE11+ 除外，但本專案 target 是現代瀏覽器）
+- 實作簡單，易於測試
+
+### 3.3 Implementation Pattern
+
+```typescript
+export function useInfiniteScroll(
+  callback: () => void,
+  options?: IntersectionObserverInit,
+) {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          callback();
+        }
+      },
+      { threshold: 0.1, ...options },
+    );
+
+    if (targetRef.current) {
+      observer.observe(targetRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [callback]);
+
+  return targetRef;
+}
+```
+
+### 3.4 Usage
+
+```tsx
+const sentinelRef = useInfiniteScroll(() => {
+  if (!isLoading && hasMore) {
+    loadMore();
+  }
+});
+
+return (
+  <div>
+    {items.map((item) => (
+      <Item key={item.id} {...item} />
+    ))}
+    <div ref={sentinelRef} /> {/* Sentinel element */}
+  </div>
+);
+```
+
+### 3.5 Alternatives Considered
+
+- ❌ **react-infinite-scroll-component**: 額外依賴，不符合 MVP 原則
+- ❌ **scroll event listener**: 效能較差（需要 throttle/debounce）
+- ✅ **IntersectionObserver**: 最佳效能，原生支援
+
+### 3.6 API Design: Client-Side Pagination (No API Page Parameter)
+
+**Decision**: Infinite scroll **不需要** API 端點附上 `page` 參數，採用 **client-side pagination**。
+
+**Rationale**:
+
+- **資料來源**：搜尋結果已包含所有 ID 列表（來自本地 JSON 或 search API 的單次回應）
+- **實作邏輯**：
+  1. 前端一次性獲得所有搜尋結果的 IDs（例如：100 筆 artist IDs）
+  2. 第一頁顯示前 20 筆 → 觸發 `getSeveralArtists(ids[0..19])`
+  3. 滾動至底部 → 載入第二頁 → 觸發 `getSeveralArtists(ids[20..39])`
+  4. 持續直到所有 IDs 載入完畢
+- **優點**：
+  1. **簡化 API 設計**：batch endpoint 僅需處理 `ids` 參數，不需 `page`, `offset`, `limit` 等分頁參數
+  2. **減少狀態管理**：前端已知總筆數與當前進度，不需從 API 回應中解析 `total`, `hasMore` 等資訊
+  3. **快取友善**：每個 batch request 的 cache key 是 `ids` 陣列，自然去重（相同 IDs = 相同快取）
+  4. **符合需求**：搜尋結果總數通常 <1000 筆，client-side pagination 完全可行
+
+**範例實作**:
+
+```tsx
+function ArtistsPage({ allArtistIds }: { allArtistIds: string[] }) {
+  const [displayedCount, setDisplayedCount] = useState(20);
+  const BATCH_SIZE = 20;
+
+  // 計算當前需要顯示的 IDs
+  const currentIds = allArtistIds.slice(0, displayedCount);
+
+  // 分批獲取（每次最多 20 筆）
+  const batches = chunk(currentIds, BATCH_SIZE);
+  const results = batches.map((batchIds) =>
+    useGetSeveralArtistsQuery(batchIds),
+  );
+
+  const loadMore = () => {
+    setDisplayedCount((prev) =>
+      Math.min(prev + BATCH_SIZE, allArtistIds.length),
+    );
+  };
+
+  const hasMore = displayedCount < allArtistIds.length;
+
+  return (
+    <div>
+      {results
+        .flatMap(({ data }) => data || [])
+        .map((artist) => (
+          <ArtistCard key={artist.id} {...artist} />
+        ))}
+      {hasMore && <div ref={useInfiniteScroll(loadMore)} />}
+    </div>
+  );
+}
+```
+
+**何時需要 API 分頁？**
+
+- ❌ **本專案不需要**：搜尋結果來自本地資料或單次 API 回應
+- ✅ **適用場景**：例如 "Browse All Artists on Spotify"，總數未知且極大（100,000+ 筆），需要 server-side pagination
+
+### 3.7 References
+
+- [MDN - Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+- [Web.dev - Infinite Scroll with Intersection Observer](https://web.dev/articles/intersectionobserver)
+
+---
+
+## 4. Skeleton Loading Best Practices
+
+### 4.1 Decision
+
+為 `ArtistCard` 和 `TrackItem` 建立對應的 skeleton components，使用 shadcn/ui 的 `Skeleton` 作為基礎元件。
+
+### 4.2 Rationale
+
+- **Layout Shift Prevention**: Skeleton 尺寸需與實際元件完全一致，避免 CLS (Cumulative Layout Shift)
+- **UX 優化**: Skeleton 應在資料載入時立即顯示（<200ms），提供視覺回饋
+- **Accessibility**: 使用 `aria-busy="true"` 和 `aria-label="載入中"` 提供無障礙支援
+
+### 4.3 Implementation Pattern
+
+```tsx
+// ArtistSkeleton.tsx
+export function ArtistSkeleton() {
+  return (
+    <Card className="p-4" aria-busy="true" aria-label="載入藝人資訊中">
+      <Skeleton className="aspect-square w-full rounded-full" />
+      <Skeleton className="mx-auto mt-3 h-5 w-3/4" />
+    </Card>
+  );
+}
+
+// TrackSkeleton.tsx
+export function TrackSkeleton() {
+  return (
+    <div
+      className="flex items-center gap-3 p-2"
+      aria-busy="true"
+      aria-label="載入歌曲資訊中"
+    >
+      <Skeleton className="h-12 w-12 rounded" />
+      <div className="flex-1">
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="mt-2 h-3 w-1/2" />
+      </div>
+    </div>
+  );
+}
+```
+
+### 4.4 Design Principles
+
+1. **Match exact dimensions**: Skeleton 尺寸需與實際元件一致 (`aspect-square`, `h-12 w-12`)
+2. **Visual hierarchy**: 主要資訊（名稱）的 skeleton 比次要資訊（年份）更寬
+3. **Consistent spacing**: 使用與實際元件相同的 gap & padding
+4. **Smooth animation**: 使用 shadcn/ui `Skeleton` 預設的 pulse 動畫
+
+### 4.5 Alternatives Considered
+
+- ❌ **Spinner/Loading indicator**: 不適合列表元件，無法預告實際內容的佈局
+- ❌ **Blank space**: 會造成 layout shift
+- ✅ **Content-aware skeleton**: 最佳 UX，符合 Design Guidelines
+
+### 4.6 References
+
+- [shadcn/ui - Skeleton](https://ui.shadcn.com/docs/components/skeleton)
+- [Web.dev - Optimize CLS](https://web.dev/articles/optimize-cls)
+
+---
+
+## 5. Cloudflare Worker Proxy for Batch Endpoints
+
+### 5.1 Decision
+
+在 `worker/src/routes/spotify.ts` 新增 `/artists?ids=...` 和 `/tracks?ids=...` routes，forwarding 至 Spotify API。
+
+### 5.2 Rationale
+
+- 現有架構已使用 Cloudflare Worker 作為 Spotify API proxy（處理 OAuth token 與 CORS）
+- Batch endpoints 僅需 forwarding，不需額外邏輯
+- 保持一致性：所有 Spotify API 請求均透過 Worker
+
+### 5.3 Implementation Pattern
+
+```typescript
+// worker/src/routes/spotify.ts
+app.get("/artists", async (c) => {
+  const ids = c.req.query("ids");
+  if (!ids) {
+    return c.json({ error: "Missing ids parameter" }, 400);
+  }
+
+  const spotifyUrl = `https://api.spotify.com/v1/artists?ids=${ids}`;
+  const response = await fetch(spotifyUrl, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await response.json();
+  return c.json(data.artists); // Return array of artists
+});
+```
+
+### 5.4 Edge Cases
+
+- ❌ 若 `ids` 參數缺失 → 回傳 400 Bad Request
+- ❌ 若 ids 數量 >20 → 回傳 400 Bad Request（前端負責 chunking）
+- ✅ 若某些 ID 不存在 → Spotify API 回傳 `null`（前端需過濾）
+
+### 5.5 References
+
+- [Hono - Query Parameters](https://hono.dev/docs/api/routing#query-parameters)
+- [Spotify API - Error Handling](https://developer.spotify.com/documentation/web-api/concepts/api-calls#error-handling)
+
+---
+
+## 6. Cache Strategy for Spotify Data
+
+### 6.1 Decision
+
+使用 RTK Query 的**永久快取策略**（infinite cache），不設定 TTL，不重新驗證。
+
+### 6.2 Rationale
+
+- **資料特性**：Spotify artists/tracks 的核心資料（名稱、圖片、專輯資訊）變動頻率極低
+  - 藝人名稱、照片：幾乎不變動
+  - 歌曲名稱、專輯封面、發行日期：完全不變動
+  - popularity 分數：會變動，但非關鍵資料
+- **使用者體驗**：永久快取可確保：
+  1. 瀏覽過的內容立即顯示（零延遲）
+  2. 離線狀態下仍可查看已快取資料
+  3. 減少不必要的網路請求
+- **成本效益**：Artist/Track 物件平均 2-5KB，快取 100 筆約 200-500KB（可接受的記憶體成本）
+
+### 6.3 Implementation
+
+```typescript
+export const spotifyApi = createApi({
+  reducerPath: "spotifyApi",
+  baseQuery: fetchBaseQuery({ baseUrl: WORKER_API_BASE_URL }),
+  tagTypes: ["Artist", "Track", "AudioFeatures"],
+  // 不設定 keepUnusedDataFor（預設無限期保留）
+  // 不設定 refetchOnMountOrArgChange
+  // 不設定 refetchOnReconnect
+  endpoints: (builder) => ({
+    /* ... */
+  }),
+});
+```
+
+### 6.4 Cache Invalidation Strategy
+
+- **自動清除**：僅在以下情況清除快取：
+  1. 使用者關閉分頁/瀏覽器（session 結束）
+  2. 使用者手動清除瀏覽器快取
+- **手動更新**：若未來需要強制更新特定資料，可使用 `api.util.invalidateTags(['Artist'])`
+
+### 6.5 Alternatives Considered
+
+- ❌ **60s TTL** (原提案): 不必要的重新驗證，增加網路請求
+- ❌ **refetchOnReconnect**: Artist/Track 資料不需在重連後更新
+- ✅ **Infinite cache**: 最符合資料特性與使用者需求
+
+### 6.6 References
+
+- [RTK Query - Cache Behavior](https://redux-toolkit.js.org/rtk-query/usage/cache-behavior)
+- [RTK Query - Customizing Queries](https://redux-toolkit.js.org/rtk-query/usage/customizing-queries)
+
+---
+
+## 7. 服務檔案整合決策
+
+### 7.1 Decision
+
+**保持分離**：`spotify-api.ts` 與 `index.ts` 維持現有結構，不進行合併。
+
+### 7.2 Rationale
+
+1. **職責分離**：
+   - `spotify-api.ts`：RTK Query API slice 定義、endpoints、hooks 邏輯
+   - `index.ts`：統一導出點，作為 public API 表面
+
+2. **未來擴展性**：
+   - 可能新增其他 API service（如 YouTube API）
+   - `index.ts` 可統一導出多個 service
+
+3. **匯入一致性**：
+   - 全專案使用 `@/services` 作為進入點
+   - 符合現有專案慣例與 Constitution III（可測試性）
+
+4. **Batch endpoints 新增位置**：
+   - 直接在 `spotify-api.ts` 的 `endpoints` 區塊新增
+   - `index.ts` 自動繼承新 hooks（透過 re-export）
+
+### 7.3 Implementation
+
+```typescript
+// src/services/spotify-api.ts
+export const spotifyApi = createApi({
+  // ... existing config
+  endpoints: (builder) => ({
+    getArtist: builder.query<...>({ ... }),
+    getTrack: builder.query<...>({ ... }),
+    getAudioFeatures: builder.query<...>({ ... }),
+    // 新增 batch endpoints
+    getSeveralArtists: builder.query<...>({ ... }),
+    getSeveralTracks: builder.query<...>({ ... }),
+  }),
+});
+
+export const {
+  useGetArtistQuery,
+  useGetTrackQuery,
+  useGetAudioFeaturesQuery,
+  // 新增
+  useGetSeveralArtistsQuery,
+  useGetSeveralTracksQuery,
+} = spotifyApi;
+```
+
+```typescript
+// src/services/index.ts - 無需修改，自動繼承新 hooks
+export {
+  spotifyApi,
+  useGetArtistQuery,
+  useGetTrackQuery,
+  useGetAudioFeaturesQuery,
+  useGetSeveralArtistsQuery, // 新增
+  useGetSeveralTracksQuery, // 新增
+} from "@/services/spotify-api";
+```
+
+### 7.4 Alternatives Considered
+
+| 方案                      | 優點               | 缺點                            | 結論   |
+| ------------------------- | ------------------ | ------------------------------- | ------ |
+| **保持分離（採用）**      | 職責清晰、擴展性佳 | 多一個檔案                      | 推薦   |
+| 合併為單一檔案            | 減少檔案數         | 失去分離優勢                    | 不採用 |
+| 建立新檔案 (batch-api.ts) | 分離 batch 邏輯    | 過度拆分、不符合 RTK Query 慣例 | 不採用 |
+
+### 7.5 References
+
+- [RTK Query - Code Splitting](https://redux-toolkit.js.org/rtk-query/usage/code-splitting)
+
+---
+
+## Summary
+
+所有研究項目均已解決，沒有 NEEDS CLARIFICATION 項目。關鍵技術決策：
+
+1. ✅ RTK Query batch fetch 使用 `onQueryStarted` + `upsertQueryData` 填入快取
+2. ✅ Spotify API 官方限制 50 筆/次，專案採用 20 筆/次（平衡資料量與請求數）
+3. ✅ Infinite scroll 使用 IntersectionObserver（原生 API，最佳效能）
+4. ✅ Skeleton 元件完全符合實際元件尺寸，避免 CLS
+5. ✅ Cloudflare Worker 新增 batch routes，forwarding 至 Spotify API
+6. ✅ 快取策略：永久快取（資料變動頻率極低，無需重新驗證）
+7. ✅ 服務檔案整合：保持分離（spotify-api.ts + index.ts）
+
+**Status**: ✅ Phase 0 Complete - Ready for Phase 1 (Data Model & Contracts)

--- a/specs/005-batch-fetch-caching/spec.md
+++ b/specs/005-batch-fetch-caching/spec.md
@@ -1,0 +1,207 @@
+# Feature Specification: Batch Fetch & Caching
+
+**Feature Branch**: `005-batch-fetch-caching`
+**Created**: 2025-11-21
+**Status**: Design Complete
+**Input**: User description: "開發資料批次獲取與快取功能..."
+
+## User Scenarios & Testing
+
+### User Story 1 - Batch Data Fetching (Priority: P1)
+
+As a developer, I want to fetch details for multiple artists or tracks in a single API request so that the application performance is optimized and API rate limits are respected.
+
+**Why this priority**: Foundation for performance improvements and required for the search page optimization. Reduces network chatter significantly.
+
+**Independent Test**:
+
+- Trigger a data fetch for a list of items.
+- Verify only one network request is made to the backend.
+- Verify that subsequent requests for individual items from that list are served from the local cache without new network requests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a list of 5 artist IDs, **When** the batch fetch mechanism is invoked, **Then** a single HTTP request is sent to the server.
+2. **Given** the batch request completes, **When** the system requests details for one of those IDs individually, **Then** it returns data immediately without a network request.
+3. **Given** a list of 20+ IDs, **When** the batch fetch logic is used, **Then** it automatically chunks requests into batches of 20 IDs (Spotify API limit).
+
+---
+
+### User Story 2 - Search Page Optimization (Priority: P2)
+
+As a user, I want to see artist and track images in the search results immediately, with efficient data loading.
+
+**Why this priority**: Improves the core user experience of the search feature, which is a primary entry point.
+
+**Independent Test**:
+
+- Perform a search returning multiple results.
+- Observe network traffic.
+- Confirm that after the search results are obtained, the details (images) are fetched in a single batch request rather than multiple individual requests.
+
+**Acceptance Scenarios**:
+
+1. **Given** I search for a term, **When** the results appear, **Then** the artist and track images are displayed.
+2. **Given** the results are loading, **When** I check the network activity, **Then** I see a single batch request for the visible items' details.
+
+---
+
+### User Story 3 - Infinite Scroll for Full Results View (Priority: P2)
+
+As a user, I want to browse all search results by scrolling continuously, without clicking "Next Page".
+
+**Why this priority**: Modernizes the UI and makes browsing large lists easier.
+
+**Note**: This applies to the "artists" and "tracks" category views within the existing search page (not a separate page).
+
+**Independent Test**:
+
+- On the search page, switch to "Artists" category (full results view).
+- Scroll to the bottom.
+- Verify that the next set of results loads automatically and appends to the list.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am viewing full results (category = "artists" or "tracks"), **When** I scroll within 300px of the bottom, **Then** the next batch of results is fetched.
+2. **Given** new results are loaded, **When** they appear, **Then** their details are also batch fetched (if not included in the list response).
+3. **Given** I scroll quickly, **When** data is loading, **Then** placeholder loaders are shown.
+
+---
+
+### User Story 4 - Skeleton Loading States (Priority: P3)
+
+As a user, I want to see smooth placeholder animations while data is loading, instead of blank spaces or layout shifts.
+
+**Why this priority**: Polish and perceived performance.
+
+**Independent Test**:
+
+- Throttle network speed.
+- Load the search page (any category view).
+- Verify skeleton blocks match the size and layout of the final content.
+
+**Acceptance Scenarios**:
+
+1. **Given** the search results are fetching, **When** waiting, **Then** I see skeleton rows/cards matching the result layout.
+2. **Given** the full results view is loading more items via infinite scroll, **When** scrolling, **Then** new skeletons appear at the bottom before the real data.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide batch API endpoints for fetching multiple artists and tracks.
+- **FR-002**: The batch endpoints MUST accept a list of IDs and return the corresponding data objects.
+- **FR-003**: The batch fetching mechanism MUST populate the client-side cache for individual items, ensuring subsequent single-item lookups hit the cache.
+- **FR-004**: Search Page MUST use batch fetching for the displayed results to minimize network requests.
+- **FR-005**: Full results views (category = "artists" or "tracks") MUST implement infinite scroll logic, triggering load when user scrolls within 300px of the bottom, loading 20 items per batch.
+- **FR-006**: Full results views MUST use batch fetching for the newly loaded items if full details are needed.
+- **FR-007**: System MUST display content-specific skeleton loaders (placeholders) during loading states.
+- **FR-008**: Client-side cache settings MUST be optimized using infinite TTL (永久快取) for Artist/Track basic data to maximize cache hit rate (target: >90%), as this data rarely changes and RTK Query's in-memory cache is automatically cleared on page reload.
+- **FR-009**: System MUST implement silent degradation for batch fetch failures — failed items display default placeholder images without blocking the UI or showing error toasts.
+- **FR-010**: Backend batch endpoints MUST validate request size and return HTTP 400 Bad Request if more than 20 IDs are provided in a single request.
+- **FR-011**: Frontend MUST handle batch API 400 errors gracefully by logging the error (for debugging) and applying silent degradation (FR-009). This scenario indicates a frontend bug (improper chunking) and should be monitored.
+
+### UX Specifications
+
+#### Infinite Scroll UX
+
+- **UX-001**: 當所有資料已載入完畢時，MUST 顯示「已顯示全部結果」文字提示於列表底部。
+- **UX-002**: Infinite scroll 載入失敗時，MUST 自動重試最多 2 次（每次間隔 1 秒，使用 exponential backoff）；若仍失敗，MUST 於列表底部顯示 inline 重試按鈕。
+- **UX-003**: Infinite scroll MUST 實作防重複觸發機制（載入中時忽略新的觸發事件），避免重複請求。
+- **UX-004**: Infinite scroll 載入中時，MUST 於列表底部顯示 skeleton loaders（數量對應每批載入數量：20 個）。
+
+#### Skeleton Loading UX
+
+- **UX-005**: Skeleton 動畫 MUST 使用 pulse 效果（shadcn/ui 預設的整體明暗閃爍動畫）。
+- **UX-006**: Artist skeleton 佈局：圓形頭像 skeleton + 名稱文字 skeleton（與 ArtistCard 尺寸一致）。
+- **UX-007**: Track skeleton 佈局：方形專輯封面 skeleton + 歌曲資訊文字 skeleton（與 TrackItem 尺寸一致）。
+- **UX-008**: Skeleton 元件 MUST 包含無障礙屬性：`aria-busy="true"` 與描述性 `aria-label`。
+
+#### Placeholder Image UX
+
+- **UX-009**: 失敗項目的 placeholder image MUST 使用專案品牌色（`--primary` 或 `--muted`）作為背景色。
+- **UX-010**: Artist placeholder MUST 顯示人像圖示（如 `react-icons/ri` 的 `RiUser3Line` icon）於品牌色背景上。
+- **UX-011**: Track placeholder MUST 顯示音符圖示（如 `react-icons/ri` 的 `RiMusic2Fill` icon）於品牌色背景上。
+- **UX-012**: Placeholder 尺寸 MUST 與正常圖片尺寸完全一致，避免 layout shift。
+
+#### Empty State UX（增強現有實作）
+
+- **UX-013**: 搜尋結果為空時，SHOULD 增強現有空狀態 UI（[search-page.tsx:85-90](../../src/pages/search-page.tsx#L85-L90)），新增：
+  - 插圖：使用 `react-icons/ri` 的 `RiSearchLine` 圖標（64x64px，`--muted-foreground` 色）
+  - 保留現有主標題文字：「未找到 "{query}" 相關結果」
+  - 新增副標題建議：「嘗試其他關鍵字或檢查拼字」
+
+### Key Entities
+
+- **Artist**: Full artist data object.
+- **Track**: Full track data object.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Loading 20 search results triggers at most 2 API requests (1 search + 1 batch detail fetch) instead of 21.
+- **SC-002**: Cache hit rate for individual item details on the search page is >90%.
+- **SC-003**: Full results view (artists or tracks category) supports scrolling through at least 100 items without error.
+- **SC-004**: Skeleton loaders are visible for at least 200ms (or until load) preventing layout shift (CLS < 0.1).
+
+## Clarifications
+
+### Session 2025-11-21
+
+- Q: "View All" 是獨立頁面還是現有功能？ → A: 是 search-page.tsx 中透過 category 狀態的 conditional rendering，非獨立頁面。
+- Q: Batch API chunking 的 chunk size？ → A: 20 IDs per chunk（Spotify API 典型限制）
+- Q: Batch API 失敗時的處理策略？ → A: Silent degradation（靜默降級，失敗項目顯示預設圖片/placeholder）
+- Q: Infinite scroll 觸發距離？ → A: 300px from bottom（標準值，平衡預載與效率）
+- Q: Infinite scroll 每次載入數量？ → A: 20 items per load（考量不同裝置與網路性能，優先保證 UX）
+- Q: 後端 Batch API 是否需要驗證 ID 數量上限？ → A: 是，超過 20 IDs 回傳 400 Bad Request；前端需優雅處理此錯誤
+
+### Session 2025-11-21 (UX Checklist Review)
+
+- Q: Infinite scroll 結尾狀態？ → A: 顯示「已顯示全部結果」文字提示
+- Q: Infinite scroll 載入失敗處理？ → A: 自動重試最多 2 次，仍失敗則顯示 inline 重試按鈕
+- Q: Placeholder image 規格？ → A: 專案品牌色背景 + 對應圖示（Artist=User icon, Track=Music icon）
+- Q: 搜尋空狀態 UI？ → A: 增強現有實作，新增插圖與副標題建議
+- Q: View All 按鈕？ → A: 已於現有實作中完成（ghost button, 標題右側）
+- Q: Skeleton 動畫效果？ → A: Pulse（shadcn/ui 預設）
+
+## Assumptions
+
+- The backend forwards batch requests correctly to the external provider.
+- Search results provide IDs that can be used for batch fetching.
+- Infinite scroll will be implemented using standard intersection detection techniques.
+- The existing search page ([search-page.tsx](../../src/pages/search-page.tsx)) has already implemented basic search functionality.
+- **"View All" is NOT a separate page** — it is a category-based conditional rendering within the existing search page:
+  - `category === "all"`: Preview mode showing limited artists & tracks (no infinite scroll needed)
+  - `category === "artists"`: Full artist results view (requires batch fetching for images)
+  - `category === "tracks"`: Full track results view (requires batch fetching for images)
+
+## Cache Strategy Rationale
+
+### Why Infinite TTL?
+
+本專案採用**永久快取（infinite TTL）**策略，具體理由如下：
+
+1. **資料特性**: Spotify Artist/Track 基本資料（名稱、圖片、專輯封面）變更頻率極低（數月至數年），屬於接近靜態的資料。
+2. **RTK Query 快取行為**: RTK Query 使用 in-memory cache（記憶體快取），快取存在於 Redux store 中。當使用者重新整理頁面時，JavaScript 重新執行，Redux store 重建，**快取會自動完全清空**。因此永久快取只在單次 session 內有效。
+3. **效能目標**: 永久快取是達成 SC-002（快取命中率 >90%）的必要條件。在單次 session 內的 SPA 導航時，使用者可獲得零延遲的即時響應。
+4. **API 效率**: 消除不必要的重新驗證請求，減少 API quota 消耗，避免浪費外部 API 呼叫次數。
+
+### 可接受的風險
+
+- **長時間 session 資料過期風險**: 使用者若在同一分頁停留極長時間（數小時至數天）且不重新整理，期間 Spotify 若更新資料，使用者會看到過期資料。
+  - **風險評估**: 極低機率（Spotify 資料變更頻率極低）× 極低影響（僅影響外觀，不影響功能）= 可接受風險
+  - **使用者緩解措施**: 重新整理頁面即可立即取得最新資料
+
+### 替代方案評估
+
+以下為其他快取策略的比較：
+
+| 策略                 | 快取命中率 | API quota 消耗 | 資料新鮮度          | 使用者體驗            | 評估結果         |
+| -------------------- | ---------- | -------------- | ------------------- | --------------------- | ---------------- |
+| **永久快取（採用）** | ✅ >90%    | ✅ 最低        | ⚠️ Session 內不更新 | ✅ 最佳（零延遲）     | **推薦**         |
+| 60s TTL              | ❌ <70%    | ❌ 高          | ✅ 最新             | ❌ 差（頻繁 loading） | 不採用           |
+| 1h TTL               | ⚠️ ~80%    | ⚠️ 中          | ✅ 每小時更新       | ⚠️ 中                 | 較保守           |
+| 24h TTL              | ✅ >85%    | ✅ 低          | ✅ 每日更新         | ✅ 好                 | 可接受的替代方案 |
+
+**結論**: 60s TTL（原 spec 草稿提及）會導致快取命中率不足、過度 API 請求，且使用者體驗差（頻繁出現 loading state），因此不採用。若未來在生產環境中發現資料新鮮度確實有問題，可改用 24h TTL 作為保守替代方案。

--- a/specs/005-batch-fetch-caching/spec.md
+++ b/specs/005-batch-fetch-caching/spec.md
@@ -165,6 +165,13 @@ As a user, I want to see smooth placeholder animations while data is loading, in
 - Q: View All 按鈕？ → A: 已於現有實作中完成（ghost button, 標題右側）
 - Q: Skeleton 動畫效果？ → A: Pulse（shadcn/ui 預設）
 
+### Session 2025-11-22 (Bug Fix)
+
+- **Bug**: Infinite scroll 從 preview 模式切換到 full 模式後不觸發
+- **根因**: `useInfiniteScroll` hook 使用 `useRef` + `useEffect`，當 sentinel 元素動態出現時，effect 不會重新執行，導致 IntersectionObserver 從未被創建
+- **修復**: 改用 callback ref pattern，確保 DOM 元素出現時自動設置 observer
+- **影響檔案**: `src/hooks/use-infinite-scroll.ts`
+
 ## Assumptions
 
 - The backend forwards batch requests correctly to the external provider.

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -19,8 +19,8 @@
 
 **目的**：專案初始化與工具函式
 
-- [ ] T001 [P] 在 src/lib/utils.ts 建立 chunking 工具函式
-- [ ] T002 [P] 在 src/components/ui/placeholder-image.tsx 新增 placeholder 圖片元件（ArtistPlaceholder、TrackPlaceholder）
+- [x] T001 [P] 在 src/lib/utils.ts 建立 chunking 工具函式
+- [x] T002 [P] 在 src/components/ui/placeholder-image.tsx 新增 placeholder 圖片元件（ArtistPlaceholder、TrackPlaceholder）
 
 ---
 

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -30,8 +30,8 @@
 
 **注意**：批次 API 端點是基礎——所有前端功能都依賴於此。
 
-- [ ] T003 在 worker/src/routes/spotify.ts 實作 GET /api/spotify/artists 批次端點（含 ID 數量驗證，>20 回傳 400）
-- [ ] T004 在 worker/src/routes/spotify.ts 實作 GET /api/spotify/tracks 批次端點（含 ID 數量驗證，>20 回傳 400）
+- [x] T003 在 worker/src/routes/spotify.ts 實作 GET /api/spotify/artists 批次端點（含 ID 數量驗證，>20 回傳 400）
+- [x] T004 在 worker/src/routes/spotify.ts 實作 GET /api/spotify/tracks 批次端點（含 ID 數量驗證，>20 回傳 400）
 
 **檢查點**：後端就緒——現在可以實作 RTK Query 端點
 

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -91,11 +91,11 @@
 
 ### 使用者故事 3 實作
 
-- [ ] T013 [US3] 在 src/hooks/use-infinite-scroll.ts 建立使用 IntersectionObserver 的 useInfiniteScroll hook（含防重複觸發機制）
-- [ ] T014 [US3] 在 src/components/search/artist-results.tsx 為 category="artists" 檢視實作無限捲動
-- [ ] T015 [US3] 在 src/components/search/track-results.tsx 為 category="tracks" 檢視實作無限捲動
-- [ ] T016 [US3] 在 src/components/search/artist-results.tsx 新增「已顯示全部結果」訊息與重試按鈕 UI
-- [ ] T017 [US3] 在 src/components/search/track-results.tsx 新增「已顯示全部結果」訊息與重試按鈕 UI
+- [x] T013 [US3] 在 src/hooks/use-infinite-scroll.ts 建立使用 IntersectionObserver 的 useInfiniteScroll hook（含防重複觸發機制）
+- [x] T014 [US3] 在 src/components/search/artist-results.tsx 為 category="artists" 檢視實作無限捲動
+- [x] T015 [US3] 在 src/components/search/track-results.tsx 為 category="tracks" 檢視實作無限捲動
+- [x] T016 [US3] 在 src/components/search/artist-results.tsx 新增「已顯示全部結果」訊息與重試按鈕 UI
+- [x] T017 [US3] 在 src/components/search/track-results.tsx 新增「已顯示全部結果」訊息與重試按鈕 UI
 
 **檢查點**：完整結果檢視支援 100+ 項目並自動載入
 
@@ -113,8 +113,8 @@
 
 ### 使用者故事 4 實作
 
-- [ ] T018 [P] [US4] 在 src/components/search/artist-results.tsx 整合無限捲動的 skeleton 載入（底部載入器）
-- [ ] T019 [P] [US4] 在 src/components/search/track-results.tsx 整合無限捲動的 skeleton 載入（底部載入器）
+- [x] T018 [P] [US4] 在 src/components/search/artist-results.tsx 整合無限捲動的 skeleton 載入（底部載入器）
+- [x] T019 [P] [US4] 在 src/components/search/track-results.tsx 整合無限捲動的 skeleton 載入（底部載入器）
 
 **檢查點**：載入時顯示 skeleton 載入器，CLS < 0.1
 

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -1,0 +1,225 @@
+# 任務清單：Batch Fetch & Caching
+
+**輸入**：設計文件來自 `/specs/005-batch-fetch-caching/`
+**前置文件**：plan.md、spec.md、research.md、data-model.md、contracts/
+
+**測試**：規格文件未明確要求測試，依範本指引略過。
+
+**組織方式**：任務依使用者故事分組，以便獨立實作與測試各個故事。
+
+## 格式：`[ID] [P?] [Story] 描述`
+
+- **[P]**：可平行執行（不同檔案、無相依性）
+- **[Story]**：此任務所屬的使用者故事（如 US1、US2、US3、US4）
+- 描述中包含確切檔案路徑
+
+---
+
+## 第一階段：設定（共用基礎設施）
+
+**目的**：專案初始化與工具函式
+
+- [ ] T001 [P] 在 src/lib/utils.ts 建立 chunking 工具函式
+- [ ] T002 [P] 在 src/components/ui/placeholder-image.tsx 新增 placeholder 圖片元件（ArtistPlaceholder、TrackPlaceholder）
+
+---
+
+## 第二階段：基礎建設（阻塞前置條件）
+
+**目的**：後端批次 API 端點，所有使用者故事都依賴這些端點
+
+**注意**：批次 API 端點是基礎——所有前端功能都依賴於此。
+
+- [ ] T003 在 worker/src/routes/spotify.ts 實作 GET /api/spotify/artists 批次端點（含 ID 數量驗證，>20 回傳 400）
+- [ ] T004 在 worker/src/routes/spotify.ts 實作 GET /api/spotify/tracks 批次端點（含 ID 數量驗證，>20 回傳 400）
+
+**檢查點**：後端就緒——現在可以實作 RTK Query 端點
+
+---
+
+## 第三階段：使用者故事 1 - 批次資料獲取（優先級：P1）MVP
+
+**目標**：透過單一 API 請求獲取多個藝人或歌曲的詳細資料，並自動填充快取
+
+**獨立測試**：
+
+- 觸發一個項目列表的資料獲取
+- 驗證僅發送一次網路請求至後端
+- 驗證後續對該列表中個別項目的請求直接從快取取得，無新的網路請求
+
+### 使用者故事 1 實作
+
+- [ ] T005 [US1] 在 src/services/spotify-api.ts 新增 getSeveralArtists 端點，含 onQueryStarted 快取填充
+- [ ] T006 [US1] 在 src/services/spotify-api.ts 新增 getSeveralTracks 端點，含 onQueryStarted 快取填充
+- [ ] T007 [US1] 在 src/services/index.ts 匯出新 hooks（useGetSeveralArtistsQuery、useGetSeveralTracksQuery）
+- [ ] T008 [US1] 在 src/services/spotify-api.ts 配置 Artist/Track 實體的永久 TTL 快取設定
+
+**檢查點**：批次獲取基礎完成——快取命中率 >90% 可達成
+
+---
+
+## 第四階段：使用者故事 2 - 搜尋頁面優化（優先級：P2）
+
+**目標**：以高效的批次資料載入方式在搜尋結果中顯示藝人和歌曲圖片
+
+**獨立測試**：
+
+- 執行一次搜尋，回傳多個結果
+- 觀察網路流量
+- 確認詳細資料是透過單一批次請求獲取，而非多個個別請求
+
+### 使用者故事 2 實作
+
+- [ ] T009 [P] [US2] 在 src/components/artist/skeleton.tsx 建立 ArtistSkeleton 元件（含 aria-busy、aria-label 無障礙屬性）
+- [ ] T010 [P] [US2] 在 src/components/track/skeleton.tsx 建立 TrackSkeleton 元件（含 aria-busy、aria-label 無障礙屬性）
+- [ ] T011 [US2] 在 src/components/search/artist-results.tsx 整合批次獲取至 ArtistSearchResults 元件
+- [ ] T012 [US2] 在 src/components/search/track-results.tsx 整合批次獲取至 TrackSearchResults 元件
+
+**檢查點**：搜尋頁面透過批次獲取顯示圖片（2 次請求取代 21+ 次）
+
+---
+
+## 第五階段：使用者故事 3 - 完整結果檢視的無限捲動（優先級：P2）
+
+**目標**：透過持續捲動瀏覽所有搜尋結果，無需分頁按鈕
+
+**獨立測試**：
+
+- 在搜尋頁面切換到「藝人」分類（完整結果檢視）
+- 捲動至底部
+- 驗證下一批結果自動載入並附加到列表
+
+### 使用者故事 3 實作
+
+- [ ] T013 [US3] 在 src/hooks/use-infinite-scroll.ts 建立使用 IntersectionObserver 的 useInfiniteScroll hook（含防重複觸發機制）
+- [ ] T014 [US3] 在 src/components/search/artist-results.tsx 為 category="artists" 檢視實作無限捲動
+- [ ] T015 [US3] 在 src/components/search/track-results.tsx 為 category="tracks" 檢視實作無限捲動
+- [ ] T016 [US3] 在 src/components/search/artist-results.tsx 新增「已顯示全部結果」訊息與重試按鈕 UI
+- [ ] T017 [US3] 在 src/components/search/track-results.tsx 新增「已顯示全部結果」訊息與重試按鈕 UI
+
+**檢查點**：完整結果檢視支援 100+ 項目並自動載入
+
+---
+
+## 第六階段：使用者故事 4 - Skeleton 載入狀態（優先級：P3）
+
+**目標**：在資料載入時顯示平滑的佔位動畫，防止版面位移
+
+**獨立測試**：
+
+- 限速網路速度
+- 載入搜尋頁面（任何分類檢視）
+- 驗證 skeleton 區塊與最終內容的尺寸和版面相符
+
+### 使用者故事 4 實作
+
+- [ ] T018 [P] [US4] 在 src/components/search/artist-results.tsx 整合無限捲動的 skeleton 載入（底部載入器）
+- [ ] T019 [P] [US4] 在 src/components/search/track-results.tsx 整合無限捲動的 skeleton 載入（底部載入器）
+
+**檢查點**：載入時顯示 skeleton 載入器，CLS < 0.1
+
+---
+
+## 第七階段：潤飾與跨功能關注點
+
+**目的**：UX 增強與錯誤處理改善
+
+- [ ] T020 [P] 在 src/pages/search-page.tsx 增強空狀態 UI，加入插圖和副標題
+- [ ] T021 [P] 在 src/components/search/artist-results.tsx 實作批次獲取失敗的靜默降級（placeholder 圖片）
+- [ ] T022 [P] 在 src/components/search/track-results.tsx 實作批次獲取失敗的靜默降級（placeholder 圖片）
+- [ ] T023 在 src/services/spotify-api.ts 新增批次 API 400 錯誤處理與日誌記錄
+- [ ] T024 執行 quickstart.md 驗證並確認所有驗收情境
+
+---
+
+## 相依性與執行順序
+
+### 階段相依性
+
+- **設定（第一階段）**：無相依性——可立即開始
+- **基礎建設（第二階段）**：依賴設定——阻塞所有使用者故事
+- **使用者故事 1（第三階段）**：依賴基礎建設（第二階段）
+- **使用者故事 2（第四階段）**：依賴使用者故事 1（需要批次端點）
+- **使用者故事 3（第五階段）**：依賴使用者故事 2（擴展搜尋結果元件）
+- **使用者故事 4（第六階段）**：依賴使用者故事 2（增強 skeleton 元件）
+- **潤飾（第七階段）**：依賴所有使用者故事完成
+
+### 使用者故事相依性
+
+- **US1（批次資料獲取）**：基礎——所有其他故事都依賴此故事
+- **US2（搜尋頁面優化）**：依賴 US1（使用批次端點）
+- **US3（無限捲動）**：依賴 US2（擴展搜尋結果元件）
+- **US4（Skeleton 載入）**：依賴 US2（增強現有 skeleton）
+
+### 各使用者故事內部順序
+
+- 後端路由先於前端端點
+- RTK Query 端點先於元件整合
+- Skeleton 元件先於載入狀態整合
+- 核心實作先於潤飾功能
+
+### 平行執行機會
+
+- T001、T002：設定任務可平行執行
+- T009、T010：Skeleton 元件可平行執行
+- T018、T019：US4 Skeleton 載入任務可平行執行
+- T020、T021、T022：不同檔案的潤飾任務可平行執行
+
+---
+
+## 平行執行範例：第一階段設定
+
+```bash
+# 同時啟動設定任務：
+Task: "在 src/lib/utils.ts 建立 chunking 工具函式"
+Task: "在 src/components/ui/placeholder-image.tsx 新增 placeholder 圖片元件"
+```
+
+## 平行執行範例：使用者故事 2 Skeleton 元件
+
+```bash
+# 同時啟動 skeleton 元件：
+Task: "在 src/components/artist/skeleton.tsx 建立 ArtistSkeleton 元件"
+Task: "在 src/components/track/skeleton.tsx 建立 TrackSkeleton 元件"
+```
+
+---
+
+## 實作策略
+
+### MVP 優先（使用者故事 1-2）
+
+1. 完成第一階段：設定
+2. 完成第二階段：基礎建設（後端批次端點）
+3. 完成第三階段：使用者故事 1（RTK Query 批次端點）
+4. 完成第四階段：使用者故事 2（搜尋頁面優化）
+5. **停下來驗證**：搜尋頁面透過批次獲取顯示圖片
+6. 準備好即可部署/演示
+
+### 漸進式交付
+
+1. 設定 + 基礎建設 + US1 -> 批次獲取基礎設施就緒
+2. 新增 US2 -> 搜尋頁面已優化 -> 部署/演示（MVP！）
+3. 新增 US3 -> 無限捲動 -> 部署/演示
+4. 新增 US4 -> Skeleton 潤飾 -> 部署/演示
+5. 潤飾階段 -> 最終增強
+
+### 成功指標
+
+| 指標                   | 目標             | 使用者故事 |
+| ---------------------- | ---------------- | ---------- |
+| 20 筆結果的 API 請求數 | 2（搜尋 + 批次） | US1、US2   |
+| 快取命中率             | >90%             | US1        |
+| 無限捲動項目數         | 100+             | US3        |
+| CLS                    | <0.1             | US4        |
+
+---
+
+## 備註
+
+- [P] 任務 = 不同檔案、無相依性
+- [Story] 標籤將任務對應到特定使用者故事以便追蹤
+- 批次大小限制：每次請求最多 20 個 ID（Spotify API 限制）
+- 快取策略：永久 TTL（基於 session，頁面重整時清除）
+- 靜默降級：失敗項目顯示 placeholder 圖片，不顯示錯誤提示
+- 每個任務或邏輯群組完成後提交

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -124,11 +124,11 @@
 
 **目的**：UX 增強與錯誤處理改善
 
-- [ ] T020 [P] 在 src/pages/search-page.tsx 增強空狀態 UI，加入插圖和副標題
-- [ ] T021 [P] 在 src/components/search/artist-results.tsx 實作批次獲取失敗的靜默降級（placeholder 圖片）
-- [ ] T022 [P] 在 src/components/search/track-results.tsx 實作批次獲取失敗的靜默降級（placeholder 圖片）
-- [ ] T023 在 src/services/spotify-api.ts 新增批次 API 400 錯誤處理與日誌記錄
-- [ ] T024 執行 quickstart.md 驗證並確認所有驗收情境
+- [x] T020 [P] 在 src/pages/search-page.tsx 增強空狀態 UI，加入插圖和副標題
+- [x] T021 [P] 在 src/components/search/artist-results.tsx 實作批次獲取失敗的靜默降級（placeholder 圖片）
+- [x] T022 [P] 在 src/components/search/track-results.tsx 實作批次獲取失敗的靜默降級（placeholder 圖片）
+- [x] T023 在 src/services/spotify-api.ts 新增批次 API 400 錯誤處理與日誌記錄
+- [x] T024 執行 quickstart.md 驗證並確認所有驗收情境
 
 ---
 

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -132,6 +132,27 @@
 
 ---
 
+## 第八階段：子元件 Hook 整合
+
+**目的**：讓子元件透過 RTK Query hook 從快取取得資料，符合 plan.md 設計意圖
+
+**設計原則**：
+
+- 父元件控制 `isLoading` 顯示 skeleton
+- 子元件使用 hook 從快取取得資料（無 skeleton 邏輯）
+- 漸進式增強：先顯示本地資料，API 返回後更新
+
+- [x] T025 [P] 修改 src/components/artist/card.tsx 使用 useGetArtistQuery hook（移除 imageUrl prop）
+- [x] T026 [P] 修改 src/components/track/item.tsx 使用 useGetTrackQuery hook（移除 imageUrl prop）
+- [x] T027 簡化 src/components/search/artist-results.tsx 移除 artistDataMap 邏輯
+- [x] T028 簡化 src/components/search/track-results.tsx 移除 trackDataMap 邏輯
+- [x] T029 更新規格文件（tasks.md）
+- [x] T030 執行驗證並提交
+
+**檢查點**：子元件透過 hook 從快取取得資料，父元件控制 skeleton 顯示
+
+---
+
 ## 相依性與執行順序
 
 ### 階段相依性

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -49,10 +49,10 @@
 
 ### 使用者故事 1 實作
 
-- [ ] T005 [US1] 在 src/services/spotify-api.ts 新增 getSeveralArtists 端點，含 onQueryStarted 快取填充
-- [ ] T006 [US1] 在 src/services/spotify-api.ts 新增 getSeveralTracks 端點，含 onQueryStarted 快取填充
-- [ ] T007 [US1] 在 src/services/index.ts 匯出新 hooks（useGetSeveralArtistsQuery、useGetSeveralTracksQuery）
-- [ ] T008 [US1] 在 src/services/spotify-api.ts 配置 Artist/Track 實體的永久 TTL 快取設定
+- [x] T005 [US1] 在 src/services/spotify-api.ts 新增 getSeveralArtists 端點，含 onQueryStarted 快取填充
+- [x] T006 [US1] 在 src/services/spotify-api.ts 新增 getSeveralTracks 端點，含 onQueryStarted 快取填充
+- [x] T007 [US1] 在 src/services/index.ts 匯出新 hooks（useGetSeveralArtistsQuery、useGetSeveralTracksQuery）
+- [x] T008 [US1] 在 src/services/spotify-api.ts 配置 Artist/Track 實體的永久 TTL 快取設定
 
 **檢查點**：批次獲取基礎完成——快取命中率 >90% 可達成
 

--- a/specs/005-batch-fetch-caching/tasks.md
+++ b/specs/005-batch-fetch-caching/tasks.md
@@ -70,10 +70,10 @@
 
 ### 使用者故事 2 實作
 
-- [ ] T009 [P] [US2] 在 src/components/artist/skeleton.tsx 建立 ArtistSkeleton 元件（含 aria-busy、aria-label 無障礙屬性）
-- [ ] T010 [P] [US2] 在 src/components/track/skeleton.tsx 建立 TrackSkeleton 元件（含 aria-busy、aria-label 無障礙屬性）
-- [ ] T011 [US2] 在 src/components/search/artist-results.tsx 整合批次獲取至 ArtistSearchResults 元件
-- [ ] T012 [US2] 在 src/components/search/track-results.tsx 整合批次獲取至 TrackSearchResults 元件
+- [x] T009 [P] [US2] 在 src/components/artist/skeleton.tsx 建立 ArtistSkeleton 元件（含 aria-busy、aria-label 無障礙屬性）
+- [x] T010 [P] [US2] 在 src/components/track/skeleton.tsx 建立 TrackSkeleton 元件（含 aria-busy、aria-label 無障礙屬性）
+- [x] T011 [US2] 在 src/components/search/artist-results.tsx 整合批次獲取至 ArtistSearchResults 元件
+- [x] T012 [US2] 在 src/components/search/track-results.tsx 整合批次獲取至 TrackSearchResults 元件
 
 **檢查點**：搜尋頁面透過批次獲取顯示圖片（2 次請求取代 21+ 次）
 

--- a/src/components/artist/card.tsx
+++ b/src/components/artist/card.tsx
@@ -1,69 +1,82 @@
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { useGetArtistQuery } from "@/services";
 import { RiUser3Line } from "react-icons/ri";
 import { Link } from "react-router-dom";
 
 /**
  * ArtistCard Component
  *
- * Purpose: 可重用的藝人卡片元件
+ * Purpose: 可重用的藝人卡片元件，透過 RTK Query hook 獲取快取資料
  *
  * Features:
  * - 圓形頭像（Spotify 藝人頭像標準）
  * - 整卡可點擊，導航至 /artist/:artistId
  * - 支援 grid 佈局（響應式）
- * - 未載入圖片時顯示 placeholder
+ * - 漸進式增強：先顯示本地資料，API 返回後更新
+ * - 無圖片時顯示 placeholder
  * - 遵循 Spotify Design Guidelines
  *
  * Props:
- * - artistId: 藝人 ID
- * - artistName: 藝人名稱
- * - imageUrl: 藝人頭像 URL（可選）
+ * - artistId: 藝人 ID（用於 RTK Query hook）
+ * - artistName: 藝人名稱（本地資料，作為 fallback）
+ *
+ * Cache Strategy:
+ * - 父元件先執行 batch fetch，透過 upsertQueryData 填充快取
+ * - 父元件使用 isLoading 控制 skeleton 顯示
+ * - 本元件的 useGetArtistQuery 會直接命中快取（無額外網路請求）
  *
  * Usage:
  *   <ArtistCard
  *     artistId="3AA28KZvwAUcZuOKwyblJQ"
  *     artistName="Gorillaz"
- *     imageUrl="https://..."
  *   />
  */
 
 interface ArtistCardProps {
   artistId: string;
   artistName: string;
-  imageUrl?: string;
   className?: string;
 }
 
 export function ArtistCard({
   artistId,
   artistName,
-  imageUrl,
   className,
 }: ArtistCardProps) {
+  // Fetch artist data from cache (populated by parent's batch fetch)
+  const { data: artist } = useGetArtistQuery(artistId);
+
+  // Progressive enhancement: use API data if available, fallback to local data
+  const displayName = artist?.name ?? artistName;
+  const imageUrl = artist?.images[0]?.url;
+
   return (
     <Link to={`/artist/${artistId}`} className={cn("block", className)}>
       <Card className="bg-muted hover:bg-muted/80 cursor-pointer p-4 transition-colors">
-        {/* Artist Image */}
+        {/* Artist Image - placeholder if no image */}
         <div className="mb-3">
           {imageUrl ? (
             <img
               src={imageUrl}
-              alt={artistName}
+              alt={displayName}
               className="aspect-square w-full rounded-full object-cover"
             />
           ) : (
-            <div className="flex aspect-square items-center justify-center rounded-full bg-secondary">
-              <span className="text-4xl text-muted-foreground" aria-label="藝人圖示">
+            <div className="bg-secondary flex aspect-square items-center justify-center rounded-full">
+              <span
+                className="text-muted-foreground text-4xl"
+                aria-label={displayName}
+              >
                 <RiUser3Line />
               </span>
             </div>
           )}
         </div>
 
-        {/* Artist Name */}
+        {/* Artist Name - always visible (local or API data) */}
         <h3 className="truncate text-center font-semibold text-white">
-          {artistName}
+          {displayName}
         </h3>
       </Card>
     </Link>

--- a/src/components/artist/skeleton.tsx
+++ b/src/components/artist/skeleton.tsx
@@ -1,0 +1,60 @@
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * ArtistSkeleton Component
+ *
+ * Skeleton loader for ArtistCard component.
+ * Matches exact dimensions to prevent layout shift (CLS < 0.1).
+ *
+ * Features:
+ * - Circular image placeholder (matches Spotify artist style)
+ * - Text placeholder for artist name
+ * - Accessible with aria-busy and aria-label
+ * - Pulse animation via shadcn/ui Skeleton
+ */
+
+interface ArtistSkeletonProps {
+  className?: string;
+}
+
+export function ArtistSkeleton({ className }: ArtistSkeletonProps) {
+  return (
+    <Card
+      className={`bg-muted p-4 ${className ?? ""}`}
+      aria-busy="true"
+      aria-label="載入藝人資訊中"
+    >
+      {/* Artist Image Skeleton - matches aspect-square w-full rounded-full */}
+      <Skeleton className="mb-3 aspect-square w-full rounded-full" />
+
+      {/* Artist Name Skeleton - matches text-center font-semibold */}
+      <Skeleton className="mx-auto h-5 w-3/4" />
+    </Card>
+  );
+}
+
+/**
+ * ArtistSkeletonList Component
+ *
+ * Renders multiple ArtistSkeleton components for loading states.
+ *
+ * @param count - Number of skeleton items to render
+ */
+interface ArtistSkeletonListProps {
+  count: number;
+  className?: string;
+}
+
+export function ArtistSkeletonList({
+  count,
+  className,
+}: ArtistSkeletonListProps) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <ArtistSkeleton key={index} className={className} />
+      ))}
+    </>
+  );
+}

--- a/src/components/search/artist-results.tsx
+++ b/src/components/search/artist-results.tsx
@@ -1,10 +1,16 @@
+import { useCallback, useState } from "react";
 import { ArtistCard } from "@/components/artist/card";
 import { ArtistSkeleton } from "@/components/artist/skeleton";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ScrollableRow } from "@/components/ui/scrollable-row";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import type { UniqueArtist } from "@/hooks/use-search";
+import { chunk } from "@/lib/utils";
 import { useGetSeveralArtistsQuery } from "@/services";
+
+const BATCH_SIZE = 20;
+const PREVIEW_COUNT = 8;
 
 interface ArtistSearchResultsProps {
   artists: UniqueArtist[];
@@ -19,20 +25,40 @@ export function ArtistSearchResults({
   onViewAll,
   query,
 }: ArtistSearchResultsProps) {
+  // Pagination state for infinite scroll (full mode only)
+  const [displayCount, setDisplayCount] = useState(BATCH_SIZE);
+
   // Get artist IDs for batch fetch
-  const displayArtists = viewMode === "preview" ? artists.slice(0, 8) : artists;
+  const displayArtists =
+    viewMode === "preview"
+      ? artists.slice(0, PREVIEW_COUNT)
+      : artists.slice(0, displayCount);
   const artistIds = displayArtists.map((a) => a.artistId);
 
-  // Batch fetch artist data (skip if no artists)
-  const { data: batchedArtists, isLoading } = useGetSeveralArtistsQuery(
-    artistIds,
-    { skip: artistIds.length === 0 },
+  // Split into batches for API calls (max 20 per request)
+  const batches = chunk(artistIds, BATCH_SIZE);
+  const currentBatchIds = batches[batches.length - 1] ?? [];
+
+  // Batch fetch artist data for current batch (skip if no artists)
+  const { data: batchedArtists, isLoading, isFetching } = useGetSeveralArtistsQuery(
+    currentBatchIds,
+    { skip: currentBatchIds.length === 0 },
   );
 
   // Create a map for quick lookup of batched artist data
   const artistDataMap = new Map(
     batchedArtists?.map((artist) => [artist.id, artist]) ?? [],
   );
+
+  // Infinite scroll
+  const hasMore = viewMode === "full" && displayCount < artists.length;
+  const loadMore = useCallback(() => {
+    if (!isFetching && hasMore) {
+      setDisplayCount((prev) => Math.min(prev + BATCH_SIZE, artists.length));
+    }
+  }, [isFetching, hasMore, artists.length]);
+
+  const sentinelRef = useInfiniteScroll(loadMore);
 
   if (artists.length === 0) {
     if (viewMode === "full") {
@@ -56,8 +82,8 @@ export function ArtistSearchResults({
     ));
 
   // Render artist cards with batched data
-  const renderArtistCards = (className?: string) =>
-    displayArtists.map((artist) => {
+  const renderArtistCards = (artistList: UniqueArtist[], className?: string) =>
+    artistList.map((artist) => {
       const batchedData = artistDataMap.get(artist.artistId);
       return (
         <ArtistCard
@@ -88,14 +114,25 @@ export function ArtistSearchResults({
                 displayArtists.length,
                 "shrink-0 basis-[12rem] snap-start",
               )
-            : renderArtistCards("shrink-0 basis-[12rem] snap-start")}
+            : renderArtistCards(displayArtists, "shrink-0 basis-[12rem] snap-start")}
         </ScrollableRow>
       ) : (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {isLoading
-            ? renderSkeletons(displayArtists.length)
-            : renderArtistCards()}
-        </div>
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {renderArtistCards(displayArtists)}
+            {isFetching && renderSkeletons(BATCH_SIZE)}
+          </div>
+
+          {/* Infinite scroll sentinel */}
+          {hasMore && <div ref={sentinelRef} className="h-4" />}
+
+          {/* All results shown message */}
+          {!hasMore && displayArtists.length > 0 && (
+            <p className="mt-6 text-center text-sm text-muted-foreground">
+              已顯示全部 {artists.length} 位藝人
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/search/artist-results.tsx
+++ b/src/components/search/artist-results.tsx
@@ -1,8 +1,10 @@
 import { ArtistCard } from "@/components/artist/card";
+import { ArtistSkeleton } from "@/components/artist/skeleton";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ScrollableRow } from "@/components/ui/scrollable-row";
 import type { UniqueArtist } from "@/hooks/use-search";
+import { useGetSeveralArtistsQuery } from "@/services";
 
 interface ArtistSearchResultsProps {
   artists: UniqueArtist[];
@@ -17,6 +19,21 @@ export function ArtistSearchResults({
   onViewAll,
   query,
 }: ArtistSearchResultsProps) {
+  // Get artist IDs for batch fetch
+  const displayArtists = viewMode === "preview" ? artists.slice(0, 8) : artists;
+  const artistIds = displayArtists.map((a) => a.artistId);
+
+  // Batch fetch artist data (skip if no artists)
+  const { data: batchedArtists, isLoading } = useGetSeveralArtistsQuery(
+    artistIds,
+    { skip: artistIds.length === 0 },
+  );
+
+  // Create a map for quick lookup of batched artist data
+  const artistDataMap = new Map(
+    batchedArtists?.map((artist) => [artist.id, artist]) ?? [],
+  );
+
   if (artists.length === 0) {
     if (viewMode === "full") {
       return (
@@ -31,7 +48,27 @@ export function ArtistSearchResults({
   }
 
   const showViewAll = viewMode === "preview" && artists.length > 4;
-  const displayArtists = viewMode === "preview" ? artists.slice(0, 8) : artists;
+
+  // Render skeleton loading state
+  const renderSkeletons = (count: number, className?: string) =>
+    Array.from({ length: count }).map((_, index) => (
+      <ArtistSkeleton key={`skeleton-${index}`} className={className} />
+    ));
+
+  // Render artist cards with batched data
+  const renderArtistCards = (className?: string) =>
+    displayArtists.map((artist) => {
+      const batchedData = artistDataMap.get(artist.artistId);
+      return (
+        <ArtistCard
+          key={artist.artistId}
+          artistId={artist.artistId}
+          artistName={batchedData?.name ?? artist.artistName}
+          imageUrl={batchedData?.images[0]?.url}
+          className={className}
+        />
+      );
+    });
 
   return (
     <div>
@@ -46,24 +83,18 @@ export function ArtistSearchResults({
 
       {viewMode === "preview" ? (
         <ScrollableRow>
-          {displayArtists.map((artist) => (
-            <ArtistCard
-              key={artist.artistId}
-              artistId={artist.artistId}
-              artistName={artist.artistName}
-              className="shrink-0 basis-[12rem] snap-start"
-            />
-          ))}
+          {isLoading
+            ? renderSkeletons(
+                displayArtists.length,
+                "shrink-0 basis-[12rem] snap-start",
+              )
+            : renderArtistCards("shrink-0 basis-[12rem] snap-start")}
         </ScrollableRow>
       ) : (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {displayArtists.map((artist) => (
-            <ArtistCard
-              key={artist.artistId}
-              artistId={artist.artistId}
-              artistName={artist.artistName}
-            />
-          ))}
+          {isLoading
+            ? renderSkeletons(displayArtists.length)
+            : renderArtistCards()}
         </div>
       )}
     </div>

--- a/src/components/search/artist-results.tsx
+++ b/src/components/search/artist-results.tsx
@@ -40,10 +40,15 @@ export function ArtistSearchResults({
   const currentBatchIds = batches[batches.length - 1] ?? [];
 
   // Batch fetch artist data for current batch (skip if no artists)
-  const { data: batchedArtists, isLoading, isFetching } = useGetSeveralArtistsQuery(
+  const { data: batchedArtists, isLoading, isFetching, isError, error } = useGetSeveralArtistsQuery(
     currentBatchIds,
     { skip: currentBatchIds.length === 0 },
   );
+
+  // Silent degradation: log error but continue with local data
+  if (isError && error) {
+    console.error("[ArtistSearchResults] Batch fetch failed, using local data:", error);
+  }
 
   // Create a map for quick lookup of batched artist data
   const artistDataMap = new Map(

--- a/src/components/search/track-results.tsx
+++ b/src/components/search/track-results.tsx
@@ -39,10 +39,15 @@ export function TrackSearchResults({
   const currentBatchIds = batches[batches.length - 1] ?? [];
 
   // Batch fetch track data for current batch (skip if no tracks)
-  const { data: batchedTracks, isLoading, isFetching } = useGetSeveralTracksQuery(
+  const { data: batchedTracks, isLoading, isFetching, isError, error } = useGetSeveralTracksQuery(
     currentBatchIds,
     { skip: currentBatchIds.length === 0 },
   );
+
+  // Silent degradation: log error but continue with local data
+  if (isError && error) {
+    console.error("[TrackSearchResults] Batch fetch failed, using local data:", error);
+  }
 
   // Create a map for quick lookup of batched track data
   const trackDataMap = new Map(

--- a/src/components/track/item.tsx
+++ b/src/components/track/item.tsx
@@ -1,27 +1,33 @@
 import { Card } from "@/components/ui/card";
+import { useGetTrackQuery } from "@/services";
 import { RiMusic2Fill } from "react-icons/ri";
 import { Link } from "react-router-dom";
 
 /**
  * TrackItem Component
  *
- * Purpose: 可重用的歌曲列表項元件
+ * Purpose: 可重用的歌曲列表項元件，透過 RTK Query hook 獲取快取資料
  *
  * Features:
  * - 水平佈局（[封面 48x48] [曲名/藝人] [年份]）
  * - 封面圓角 4px（Spotify 專輯封面標準）
  * - 藝人連結可選（showArtistLink prop）
- * - 未載入圖片時顯示 placeholder
+ * - 漸進式增強：先顯示本地資料，API 返回後更新
+ * - 無圖片時顯示 placeholder
  * - 遵循 Spotify Design Guidelines
  *
  * Props:
- * - trackId: 歌曲 ID
- * - trackName: 歌曲名稱
- * - artistName: 藝人名稱
- * - artistId: 藝人 ID
- * - releaseYear: 發行年份（可選）
- * - imageUrl: 專輯封面 URL（可選）
+ * - trackId: 歌曲 ID（用於 RTK Query hook）
+ * - trackName: 歌曲名稱（本地資料，作為 fallback）
+ * - artistName: 藝人名稱（本地資料，作為 fallback）
+ * - artistId: 藝人 ID（本地資料，作為 fallback）
+ * - releaseYear: 發行年份（本地資料，Spotify API 無此欄位）
  * - showArtistLink: 是否顯示藝人連結（預設 true）
+ *
+ * Cache Strategy:
+ * - 父元件先執行 batch fetch，透過 upsertQueryData 填充快取
+ * - 父元件使用 isLoading 控制 skeleton 顯示
+ * - 本元件的 useGetTrackQuery 會直接命中快取（無額外網路請求）
  *
  * Usage:
  *   <TrackItem
@@ -29,8 +35,7 @@ import { Link } from "react-router-dom";
  *     trackName="Feel Good Inc."
  *     artistName="Gorillaz"
  *     artistId="3AA28KZvwAUcZuOKwyblJQ"
- *     releaseYear="2005"
- *     imageUrl="https://..."
+ *     releaseYear={2005}
  *     showArtistLink={true}
  *   />
  */
@@ -41,7 +46,6 @@ interface TrackItemProps {
   artistName: string;
   artistId: string;
   releaseYear?: number;
-  imageUrl?: string;
   showArtistLink?: boolean;
 }
 
@@ -51,51 +55,64 @@ export function TrackItem({
   artistName,
   artistId,
   releaseYear,
-  imageUrl,
   showArtistLink = true,
 }: TrackItemProps) {
+  // Fetch track data from cache (populated by parent's batch fetch)
+  const { data: track } = useGetTrackQuery(trackId);
+
+  // Progressive enhancement: use API data if available, fallback to local data
+  const displayTrackName = track?.name ?? trackName;
+  const displayArtistName = track?.artists[0]?.name ?? artistName;
+  const displayArtistId = track?.artists[0]?.id ?? artistId;
+  const imageUrl = track?.album?.images[0]?.url;
+
   return (
     <Card className="bg-muted hover:bg-muted/80 p-3 transition-colors">
       <div className="flex items-center gap-3">
-        {/* Album Cover */}
+        {/* Album Cover - placeholder if no image */}
         <Link to={`/track/${trackId}`} className="flex-shrink-0">
           {imageUrl ? (
             <img
               src={imageUrl}
-              alt={trackName}
+              alt={displayTrackName}
               className="h-12 w-12 rounded object-cover"
             />
           ) : (
-            <div className="flex h-12 w-12 items-center justify-center rounded bg-secondary">
-              <span className="text-2xl text-muted-foreground" aria-label="歌曲圖示">
+            <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded">
+              <span
+                className="text-muted-foreground text-2xl"
+                aria-label={displayTrackName}
+              >
                 <RiMusic2Fill />
               </span>
             </div>
           )}
         </Link>
 
-        {/* Track Info */}
+        {/* Track Info - always visible (local or API data) */}
         <div className="min-w-0 flex-1">
           <Link to={`/track/${trackId}`}>
             <h4 className="truncate font-semibold text-white hover:underline">
-              {trackName}
+              {displayTrackName}
             </h4>
           </Link>
 
           {showArtistLink ? (
-            <Link to={`/artist/${artistId}`}>
-              <p className="hover:text-primary truncate text-sm text-muted-foreground hover:underline">
-                {artistName}
+            <Link to={`/artist/${displayArtistId}`}>
+              <p className="hover:text-primary text-muted-foreground truncate text-sm hover:underline">
+                {displayArtistName}
               </p>
             </Link>
           ) : (
-            <p className="truncate text-sm text-muted-foreground">{artistName}</p>
+            <p className="text-muted-foreground truncate text-sm">
+              {displayArtistName}
+            </p>
           )}
         </div>
 
-        {/* Release Year */}
+        {/* Release Year - from local data */}
         {releaseYear && (
-          <div className="flex-shrink-0 text-sm text-muted-foreground">
+          <div className="text-muted-foreground flex-shrink-0 text-sm">
             {releaseYear}
           </div>
         )}

--- a/src/components/track/skeleton.tsx
+++ b/src/components/track/skeleton.tsx
@@ -1,0 +1,63 @@
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * TrackSkeleton Component
+ *
+ * Skeleton loader for TrackItem component.
+ * Matches exact dimensions to prevent layout shift (CLS < 0.1).
+ *
+ * Features:
+ * - Square album cover placeholder (48x48, matches TrackItem)
+ * - Text placeholders for track name and artist
+ * - Accessible with aria-busy and aria-label
+ * - Pulse animation via shadcn/ui Skeleton
+ */
+
+export function TrackSkeleton() {
+  return (
+    <Card
+      className="bg-muted p-3"
+      aria-busy="true"
+      aria-label="載入歌曲資訊中"
+    >
+      <div className="flex items-center gap-3">
+        {/* Album Cover Skeleton - matches h-12 w-12 rounded */}
+        <Skeleton className="h-12 w-12 shrink-0 rounded" />
+
+        {/* Track Info Skeleton */}
+        <div className="min-w-0 flex-1 space-y-2">
+          {/* Track Name - matches truncate font-semibold */}
+          <Skeleton className="h-4 w-2/3" />
+
+          {/* Artist Name - matches truncate text-sm */}
+          <Skeleton className="h-3 w-1/2" />
+        </div>
+
+        {/* Release Year Skeleton */}
+        <Skeleton className="h-4 w-10 shrink-0" />
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * TrackSkeletonList Component
+ *
+ * Renders multiple TrackSkeleton components for loading states.
+ *
+ * @param count - Number of skeleton items to render
+ */
+interface TrackSkeletonListProps {
+  count: number;
+}
+
+export function TrackSkeletonList({ count }: TrackSkeletonListProps) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: count }).map((_, index) => (
+        <TrackSkeleton key={index} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/placeholder-image.tsx
+++ b/src/components/ui/placeholder-image.tsx
@@ -1,0 +1,33 @@
+import { RiMusic2Fill, RiUser3Line } from "react-icons/ri";
+
+/**
+ * ArtistPlaceholder Component
+ *
+ * Placeholder image for artist cards when no image is available.
+ * Matches ArtistCard's circular image style with a user icon.
+ */
+export function ArtistPlaceholder() {
+  return (
+    <div className="flex aspect-square items-center justify-center rounded-full bg-secondary">
+      <span className="text-4xl text-muted-foreground" aria-label="藝人圖示">
+        <RiUser3Line />
+      </span>
+    </div>
+  );
+}
+
+/**
+ * TrackPlaceholder Component
+ *
+ * Placeholder image for track items when no album cover is available.
+ * Matches TrackItem's 48x48 rounded square style with a music icon.
+ */
+export function TrackPlaceholder() {
+  return (
+    <div className="flex h-12 w-12 items-center justify-center rounded bg-secondary">
+      <span className="text-2xl text-muted-foreground" aria-label="歌曲圖示">
+        <RiMusic2Fill />
+      </span>
+    </div>
+  );
+}

--- a/src/hooks/use-infinite-scroll.ts
+++ b/src/hooks/use-infinite-scroll.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * useInfiniteScroll Hook
+ *
+ * IntersectionObserver-based infinite scroll hook for loading more content
+ * when the user scrolls near the bottom of a container.
+ *
+ * Features:
+ * - Uses native IntersectionObserver API for optimal performance
+ * - Prevents duplicate triggers with isLoading guard
+ * - Configurable threshold and root margin
+ * - Cleanup on unmount
+ *
+ * @param callback - Function to call when sentinel element is visible
+ * @param options - IntersectionObserver options
+ * @returns Ref to attach to the sentinel element
+ *
+ * @example
+ * ```tsx
+ * function ItemList() {
+ *   const [items, setItems] = useState([]);
+ *   const [isLoading, setIsLoading] = useState(false);
+ *   const [hasMore, setHasMore] = useState(true);
+ *
+ *   const loadMore = useCallback(() => {
+ *     if (!isLoading && hasMore) {
+ *       setIsLoading(true);
+ *       fetchMoreItems().then((newItems) => {
+ *         setItems(prev => [...prev, ...newItems]);
+ *         setHasMore(newItems.length > 0);
+ *         setIsLoading(false);
+ *       });
+ *     }
+ *   }, [isLoading, hasMore]);
+ *
+ *   const sentinelRef = useInfiniteScroll(loadMore);
+ *
+ *   return (
+ *     <div>
+ *       {items.map(item => <Item key={item.id} {...item} />)}
+ *       {isLoading && <LoadingSpinner />}
+ *       {hasMore && <div ref={sentinelRef} />}
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useInfiniteScroll(
+  callback: () => void,
+  options?: IntersectionObserverInit,
+) {
+  const targetRef = useRef<HTMLDivElement>(null);
+  const callbackRef = useRef(callback);
+
+  // Keep callback ref up to date without causing effect re-runs
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const handleIntersect = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry.isIntersecting) {
+        callbackRef.current();
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return undefined;
+
+    const observer = new IntersectionObserver(handleIntersect, {
+      threshold: 0.1,
+      rootMargin: "300px", // Trigger 300px before reaching the sentinel
+      ...options,
+    });
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [handleIntersect, options]);
+
+  return targetRef;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,26 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Split an array into chunks of specified size
+ *
+ * @param array - The array to split
+ * @param size - Maximum size of each chunk
+ * @returns Array of chunks
+ *
+ * @example
+ * chunk([1, 2, 3, 4, 5], 2) // [[1, 2], [3, 4], [5]]
+ * chunk(['a', 'b', 'c'], 20) // [['a', 'b', 'c']]
+ */
+export function chunk<T>(array: T[], size: number): T[][] {
+  if (size <= 0) {
+    throw new Error("Chunk size must be greater than 0")
+  }
+
+  const chunks: T[][] = []
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size))
+  }
+  return chunks
+}

--- a/src/pages/search-page.tsx
+++ b/src/pages/search-page.tsx
@@ -8,6 +8,7 @@ import { useDocumentTitle } from "@/hooks/use-document-title";
 import { useSearch } from "@/hooks/use-search";
 import type { tracksLoader } from "@/loaders/tracks-loader";
 import { Suspense, useState } from "react";
+import { RiMusicLine, RiSearchLine } from "react-icons/ri";
 import { useRouteLoaderData, useSearchParams } from "react-router-dom";
 
 /**
@@ -77,16 +78,28 @@ function SearchPageContent() {
 
       {/* Search Results */}
       {!query.trim() ? (
-        <Card className="p-8 text-center">
-          <p className="text-muted-foreground text-lg">
-            在上方搜尋框輸入藝人或歌曲名稱以開始搜尋
-          </p>
+        <Card className="flex flex-col items-center gap-4 p-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-secondary">
+            <RiSearchLine className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <div>
+            <p className="text-lg font-medium text-foreground">開始搜尋</p>
+            <p className="mt-1 text-muted-foreground">
+              在上方搜尋框輸入藝人或歌曲名稱
+            </p>
+          </div>
         </Card>
       ) : results.artists.length === 0 && results.tracks.length === 0 ? (
-        <Card className="p-8 text-center">
-          <p className="text-muted-foreground text-lg">
-            未找到 &quot;{query}&quot; 相關結果
-          </p>
+        <Card className="flex flex-col items-center gap-4 p-12 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-secondary">
+            <RiMusicLine className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <div>
+            <p className="text-lg font-medium text-foreground">找不到結果</p>
+            <p className="mt-1 text-muted-foreground">
+              未找到 &quot;{query}&quot; 相關的藝人或歌曲
+            </p>
+          </div>
         </Card>
       ) : (
         <div className="space-y-8">

--- a/src/pages/search-page.tsx
+++ b/src/pages/search-page.tsx
@@ -60,7 +60,7 @@ function SearchPageContent() {
   const showTracks = category === "all" || category === "tracks";
 
   return (
-    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 pt-20 pb-4">
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 pt-20 pb-4 sm:pt-4">
       {/* SearchBar (visible on mobile devices) */}
       <div className="fixed top-18 right-0 left-0 z-40 px-6 py-2 sm:hidden">
         <SearchBar />
@@ -79,24 +79,24 @@ function SearchPageContent() {
       {/* Search Results */}
       {!query.trim() ? (
         <Card className="flex flex-col items-center gap-4 p-12 text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-secondary">
-            <RiSearchLine className="h-8 w-8 text-muted-foreground" />
+          <div className="bg-secondary flex h-16 w-16 items-center justify-center rounded-full">
+            <RiSearchLine className="text-muted-foreground h-8 w-8" />
           </div>
           <div>
-            <p className="text-lg font-medium text-foreground">開始搜尋</p>
-            <p className="mt-1 text-muted-foreground">
+            <p className="text-foreground text-lg font-medium">開始搜尋</p>
+            <p className="text-muted-foreground mt-1">
               在上方搜尋框輸入藝人或歌曲名稱
             </p>
           </div>
         </Card>
       ) : results.artists.length === 0 && results.tracks.length === 0 ? (
         <Card className="flex flex-col items-center gap-4 p-12 text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-secondary">
-            <RiMusicLine className="h-8 w-8 text-muted-foreground" />
+          <div className="bg-secondary flex h-16 w-16 items-center justify-center rounded-full">
+            <RiMusicLine className="text-muted-foreground h-8 w-8" />
           </div>
           <div>
-            <p className="text-lg font-medium text-foreground">找不到結果</p>
-            <p className="mt-1 text-muted-foreground">
+            <p className="text-foreground text-lg font-medium">找不到結果</p>
+            <p className="text-muted-foreground mt-1">
               未找到 &quot;{query}&quot; 相關的藝人或歌曲
             </p>
           </div>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,5 +12,7 @@ export {
   spotifyApi,
   useGetArtistQuery,
   useGetAudioFeaturesQuery,
+  useGetSeveralArtistsQuery,
+  useGetSeveralTracksQuery,
   useGetTrackQuery,
 } from "@/services/spotify-api";

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -154,6 +154,160 @@ app.post("/api/spotify/token", async (c) => {
 });
 
 /**
+ * Route: GET /api/spotify/artists
+ * Returns multiple artists from Spotify API (batch endpoint)
+ *
+ * Query Parameters:
+ * - ids: Comma-separated list of Spotify artist IDs (max 20)
+ *
+ * @example GET /api/spotify/artists?ids=id1,id2,id3
+ */
+app.get("/api/spotify/artists", async (c) => {
+  const ids = c.req.query("ids");
+
+  // Validate ids parameter exists
+  if (!ids) {
+    return c.json(
+      {
+        error: "MISSING_IDS",
+        message: "Missing ids parameter",
+        status: 400,
+      } satisfies ErrorResponse,
+      400,
+    );
+  }
+
+  const idArray = ids.split(",").filter((id) => id.trim());
+
+  // Validate ids count (1-20)
+  if (idArray.length === 0 || idArray.length > 20) {
+    return c.json(
+      {
+        error: "INVALID_IDS_COUNT",
+        message: `Invalid ids count: ${idArray.length}. Must be between 1 and 20.`,
+        status: 400,
+      } satisfies ErrorResponse,
+      400,
+    );
+  }
+
+  // Validate each ID format
+  for (const id of idArray) {
+    if (!SPOTIFY_ID_REGEX.test(id)) {
+      return c.json(
+        {
+          error: "INVALID_ID_FORMAT",
+          message: `Invalid artist ID format: "${id}". Must be 22 alphanumeric characters.`,
+          status: 400,
+        } satisfies ErrorResponse,
+        400,
+      );
+    }
+  }
+
+  try {
+    const artistsData = await callSpotifyApi(
+      `/v1/artists?ids=${ids}`,
+      c.env,
+      "artists",
+    );
+    return c.json(artistsData);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    if (message.includes("SPOTIFY_API_ERROR")) {
+      return c.json(
+        {
+          error: "SPOTIFY_API_ERROR",
+          message,
+          status: 502,
+        } satisfies ErrorResponse,
+        502,
+      );
+    }
+
+    throw new HTTPException(500, { message });
+  }
+});
+
+/**
+ * Route: GET /api/spotify/tracks
+ * Returns multiple tracks from Spotify API (batch endpoint)
+ *
+ * Query Parameters:
+ * - ids: Comma-separated list of Spotify track IDs (max 20)
+ *
+ * @example GET /api/spotify/tracks?ids=id1,id2,id3
+ */
+app.get("/api/spotify/tracks", async (c) => {
+  const ids = c.req.query("ids");
+
+  // Validate ids parameter exists
+  if (!ids) {
+    return c.json(
+      {
+        error: "MISSING_IDS",
+        message: "Missing ids parameter",
+        status: 400,
+      } satisfies ErrorResponse,
+      400,
+    );
+  }
+
+  const idArray = ids.split(",").filter((id) => id.trim());
+
+  // Validate ids count (1-20)
+  if (idArray.length === 0 || idArray.length > 20) {
+    return c.json(
+      {
+        error: "INVALID_IDS_COUNT",
+        message: `Invalid ids count: ${idArray.length}. Must be between 1 and 20.`,
+        status: 400,
+      } satisfies ErrorResponse,
+      400,
+    );
+  }
+
+  // Validate each ID format
+  for (const id of idArray) {
+    if (!SPOTIFY_ID_REGEX.test(id)) {
+      return c.json(
+        {
+          error: "INVALID_ID_FORMAT",
+          message: `Invalid track ID format: "${id}". Must be 22 alphanumeric characters.`,
+          status: 400,
+        } satisfies ErrorResponse,
+        400,
+      );
+    }
+  }
+
+  try {
+    const tracksData = await callSpotifyApi(
+      `/v1/tracks?ids=${ids}`,
+      c.env,
+      "tracks",
+    );
+    return c.json(tracksData);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    if (message.includes("SPOTIFY_API_ERROR")) {
+      return c.json(
+        {
+          error: "SPOTIFY_API_ERROR",
+          message,
+          status: 502,
+        } satisfies ErrorResponse,
+        502,
+      );
+    }
+
+    throw new HTTPException(500, { message });
+  }
+});
+
+/**
  * Route: GET /api/spotify/tracks/:id
  * Returns track information from Spotify API
  */


### PR DESCRIPTION
## Summary

- **Batch API endpoints**: Add backend proxy endpoints for fetching multiple artists/tracks in a single request (max 20 IDs per request per Spotify API limits)
- **RTK Query cache population**: Implement `providesTags` pattern to distribute batch API responses into individual resource caches, enabling child components to access data via ID-based hooks without props drilling
- **Infinite scroll**: Add `useInfiniteScroll` hook with callback ref pattern for dynamic sentinel element handling, auto-retry (2x with exponential backoff), and end-of-list detection
- **Skeleton loading**: Add accessible skeleton components for artists (circular avatar + text) and tracks (square album art + info) with pulse animation and ARIA attributes
- **Enhanced UX**: Add placeholder images with brand colors and icons for failed items, improved empty states with illustrations

## Key Changes

### Backend (worker/index.ts)
- `GET /api/spotify/artists?ids=...` - Batch fetch up to 20 artists
- `GET /api/spotify/tracks?ids=...` - Batch fetch up to 20 tracks
- Request size validation (400 Bad Request if >20 IDs)

### Frontend
- **RTK Query** ([spotify-api.ts](src/services/spotify-api.ts)): `useGetSeveralArtistsQuery`, `useGetSeveralTracksQuery` with infinite TTL cache
- **Components**: Refactored `ArtistCard` and `TrackItem` to fetch their own data via ID, eliminating props drilling
- **Hooks**: New `useInfiniteScroll` with callback ref pattern (fixes dynamic element detection)
- **UI**: New skeleton components, placeholder images, enhanced empty states

## Test Plan

- [x] Search returns results with images loaded via batch fetch (verify 2 API calls max for 20 results)
- [x] Switch to "Artists" category → infinite scroll triggers at 300px from bottom
- [x] Scroll through 100+ items without errors
- [x] Skeleton loaders visible during loading with proper dimensions
- [x] Failed items show placeholder images (not broken image icons)
- [x] Empty search shows enhanced UI with icon and suggestions

## Specs

- [spec.md](specs/005-batch-fetch-caching/spec.md)
- [plan.md](specs/005-batch-fetch-caching/plan.md)

---

## 摘要 (zh-TW)

實作批次資料獲取與快取機制：

- **Batch API**：新增後端代理端點，單次請求可獲取最多 20 位藝人或歌曲
- **RTK Query 快取**：使用 `providesTags` 將批次回應分配至個別資源快取，子元件可透過 ID + hook 直接取得快取資料，避免 props drilling
- **無限捲動**：新增 `useInfiniteScroll` hook，採用 callback ref pattern 處理動態 sentinel 元素，支援自動重試與結尾偵測
- **Skeleton 載入**：新增具無障礙屬性的 skeleton 元件（pulse 動畫）
- **UX 強化**：失敗項目顯示品牌色 placeholder 圖片，搜尋空狀態新增插圖與建議文字