### PR TITLE
fix(pages): prevent error flash during data loading

### DIFF
--- a/src/pages/artist-page.tsx
+++ b/src/pages/artist-page.tsx
@@ -44,7 +44,7 @@ function ArtistPageContent() {
   >;
 
   // Get artist data for document title
-  const { data: artist } = useGetArtistQuery(artistId || "", {
+  const { data: artist, isLoading } = useGetArtistQuery(artistId || "", {
     skip: !artistId,
   });
 
@@ -57,7 +57,7 @@ function ArtistPageContent() {
     : [];
 
   // Handle invalid artist ID
-  if (!artistId || !artist) {
+  if (!artistId || (!artist && !isLoading)) {
     return (
       <div className="m-auto max-w-7xl px-6 py-12">
         <Card className="p-8 text-center">

--- a/src/pages/track-page.tsx
+++ b/src/pages/track-page.tsx
@@ -36,12 +36,14 @@ function TrackPageContent() {
   const { trackId } = useParams<{ trackId: string }>();
 
   // Get track data from Spotify API
-  const { data: track } = useGetTrackQuery(trackId || "", { skip: !trackId });
+  const { data: track, isLoading } = useGetTrackQuery(trackId || "", {
+    skip: !trackId,
+  });
 
   // Set document title
   useDocumentTitle(track ? `${track.name} | Music Hits` : "Music Hits");
 
-  if (!trackId || !track) {
+  if (!trackId || (!track && !isLoading)) {
     return (
       <div className="m-auto max-w-7xl px-6 py-12">
         <Card className="p-8 text-center">


### PR DESCRIPTION
Add isLoading state check to artist and track pages to avoid showing "not found" error while data is still being fetched.